### PR TITLE
#9 More verbose error messages: include package name 

### DIFF
--- a/packages/lockfile-lint-api/__tests__/validators.host.test.js
+++ b/packages/lockfile-lint-api/__tests__/validators.host.test.js
@@ -1,4 +1,5 @@
 const ValidatorHost = require('../src/validators/ValidateHost')
+const PackageError = require('../src/common/PackageError')
 
 describe('Validator: Host', () => {
   it('validator should throw an error when provided a string', () => {
@@ -141,5 +142,16 @@ describe('Validator: Host', () => {
         }
       ]
     })
+  })
+
+  it('validator should throw a descriptive error when one is encounterd in a package', () => {
+    const mockedPackages = {
+      '@babel/code-frame': {
+        resolved: 'debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791'
+      }
+    }
+    const validator = new ValidatorHost({packages: mockedPackages})
+
+    expect(() => validator.validate(['npm'])).toThrow(PackageError)
   })
 })

--- a/packages/lockfile-lint-api/__tests__/validators.https.test.js
+++ b/packages/lockfile-lint-api/__tests__/validators.https.test.js
@@ -1,4 +1,5 @@
 const ValidatorHTTPS = require('../src/validators/ValidateHttps')
+const PackageError = require('../src/common/PackageError')
 
 describe('Validator: HTTPS', () => {
   it('validator should throw an error when provided a string', () => {
@@ -57,5 +58,16 @@ describe('Validator: HTTPS', () => {
       type: 'success',
       errors: []
     })
+  })
+
+  it('validator should throw a descriptive error when one is encounterd in a package', () => {
+    const mockedPackages = {
+      '@babel/code-frame': {
+        resolved: 'debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791'
+      }
+    }
+    const validator = new ValidatorHTTPS({packages: mockedPackages})
+
+    expect(() => validator.validate(['npm'])).toThrow(PackageError)
   })
 })

--- a/packages/lockfile-lint-api/__tests__/validators.scheme.test.js
+++ b/packages/lockfile-lint-api/__tests__/validators.scheme.test.js
@@ -1,4 +1,5 @@
 const ValidatorScheme = require('../src/validators/ValidateScheme')
+const PackageError = require('../src/common/PackageError')
 
 describe('Validator: Protocol', () => {
   it('validator should throw an error when provided a string', () => {
@@ -57,5 +58,16 @@ describe('Validator: Protocol', () => {
       type: 'success',
       errors: []
     })
+  })
+
+  it('validator should throw a descriptive error when one is encounterd in a package', () => {
+    const mockedPackages = {
+      '@babel/code-frame': {
+        resolved: 'debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791'
+      }
+    }
+    const validator = new ValidatorScheme({packages: mockedPackages})
+
+    expect(() => validator.validate(['npm'])).toThrow(PackageError)
   })
 })

--- a/packages/lockfile-lint-api/src/common/PackageError.js
+++ b/packages/lockfile-lint-api/src/common/PackageError.js
@@ -1,0 +1,15 @@
+'use strict'
+
+module.exports = class PackageError extends Error {
+  /**
+   * constructor
+   * @param {string} packageName - the name of the package where the error occured
+   * @param {string} error - the original error object
+   */
+  constructor (packageName = '', error = {}) {
+    super()
+    this.name = error.name || 'Error'
+    this.message = `Encountered error ${error.message} in package: "${packageName}"`
+    this.stack = error.stack
+  }
+}

--- a/packages/lockfile-lint-api/src/validators/ValidateHost.js
+++ b/packages/lockfile-lint-api/src/validators/ValidateHost.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const {URL} = require('url')
+const PackageError = require('../common/PackageError')
 
 const REGISTRY = {
   npm: 'registry.npmjs.org',
@@ -28,7 +29,12 @@ module.exports = class ValidateHost {
     }
 
     for (const [packageName, packageMetadata] of Object.entries(this.packages)) {
-      const packageResolvedURL = new URL(packageMetadata.resolved)
+      let packageResolvedURL = {}
+      try {
+        packageResolvedURL = new URL(packageMetadata.resolved)
+      } catch (error) {
+        throw new PackageError(packageName, error)
+      }
 
       const allowedHosts = hosts.map(hostValue => {
         // eslint-disable-next-line security/detect-object-injection

--- a/packages/lockfile-lint-api/src/validators/ValidateHttps.js
+++ b/packages/lockfile-lint-api/src/validators/ValidateHttps.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const {URL} = require('url')
+const PackageError = require('../common/PackageError')
 
 const HTTPS_PROTOCOL = 'https:'
 
@@ -20,7 +21,12 @@ module.exports = class ValidateHttps {
     }
 
     for (const [packageName, packageMetadata] of Object.entries(this.packages)) {
-      const packageResolvedURL = new URL(packageMetadata.resolved)
+      let packageResolvedURL = {}
+      try {
+        packageResolvedURL = new URL(packageMetadata.resolved)
+      } catch (error) {
+        throw new PackageError(packageName, error)
+      }
 
       if (packageResolvedURL.protocol !== HTTPS_PROTOCOL) {
         validationResult.errors.push({

--- a/packages/lockfile-lint-api/src/validators/ValidateScheme.js
+++ b/packages/lockfile-lint-api/src/validators/ValidateScheme.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const {URL} = require('url')
+const PackageError = require('../common/PackageError')
 
 module.exports = class ValidateProtocol {
   constructor ({packages} = {}) {
@@ -22,7 +23,13 @@ module.exports = class ValidateProtocol {
     }
 
     for (const [packageName, packageMetadata] of Object.entries(this.packages)) {
-      const packageResolvedURL = new URL(packageMetadata.resolved)
+      let packageResolvedURL = {}
+      try {
+        packageResolvedURL = new URL(packageMetadata.resolved)
+      } catch (error) {
+        throw new PackageError(packageName, error)
+      }
+
       if (schemes.indexOf(packageResolvedURL.protocol) === -1) {
         // throw new Error(`detected invalid origin for package: ${packageName}`)
         validationResult.errors.push({

--- a/packages/lockfile-lint/bin/lockfile-lint.js
+++ b/packages/lockfile-lint/bin/lockfile-lint.js
@@ -31,9 +31,9 @@ try {
     validators
   })
 } catch (error) {
-  console.error('ABORTING lockfile lint process due to error exceptions')
-  console.error(error.message)
-  console.error(error.stack)
+  console.error('ABORTING lockfile lint process due to error exceptions', '\n')
+  console.error(error.message, '\n')
+  console.error(error.stack, '\n')
   console.error('error: command failed with exit code 1')
   process.exit(1)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Provide more verbose information - which includes the package name - on errors encountered during validation. In order to solve this I created a custom error type called `PackageError` which prints out the package name as well as the original error message and stacktrace. It is used in validators.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

#9 

## Motivation and Context

More informative error message.

## How Has This Been Tested?

Added a test-case for each validator. Based on mocked packages containing a bad url these test cases assert that `PackageError` was thrown.

## Screenshots (if appropriate):
Example output:
```
$ lockfile-lint -p bad-yarn.lock --allowed-hosts yarn --validate-https -t yarn
ABORTING lockfile lint process due to error exceptions 

Encountered error Invalid URL: /registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791 in package: "debug@^4.1.1" 

TypeError [ERR_INVALID_URL]: Invalid URL: /registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791
    at onParseError (internal/url.js:241:17)
    at new URL (internal/url.js:319:5)
    at ValidateHost.validate ...

error: command failed with exit code 1
```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I added a picture of a cute animal cause it's fun

![cat](https://user-images.githubusercontent.com/5598081/66708595-642d2d80-ed5b-11e9-9f1f-3ea99d23de2e.gif)

