### PR TITLE
docs: fixing typo in README.md example

### DIFF
--- a/packages/lockfile-lint-api/README.md
+++ b/packages/lockfile-lint-api/README.md
@@ -113,7 +113,7 @@ const {ValidateHost, ParseLockFile} = require('lockfile-lint-api')
 // path to the lockfile
 const yarnLockFilePath = '/path/to/my/yarn.lock'
 const options = {
-  lockFilePath: yarnLockFilePath
+  lockfilePath: yarnLockFilePath
 }
 
 // instantiate a new parser with options object


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Fixing typo in README.md

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/lirantal/lockfile-lint/issues/18

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
It makes the README.md example work without any additional debugging effort.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->
Manually tested the changes, since it is docs change, no need for unit tests.

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
- [x] I added a picture of a cute animal cause it's fun
![funnycat2](https://user-images.githubusercontent.com/15200937/66767980-2fda7e00-eecf-11e9-91b7-2154c03fa094.jpg)

