### PR TITLE
feat(emptyhostname): allow empty hostnames in api

### DIFF
--- a/packages/lockfile-lint-api/__tests__/validators.host.test.js
+++ b/packages/lockfile-lint-api/__tests__/validators.host.test.js
@@ -154,4 +154,45 @@ describe('Validator: Host', () => {
 
     expect(() => validator.validate(['npm'])).toThrow(PackageError)
   })
+
+  it('validator should not throw if emptyHostnames are allowed', () => {
+    const mockedPackages = {
+      '@babel/code-frame': {
+        resolved: 'github:XhmikosR/metalsmith-permalinks#master'
+      }
+    }
+    const validator = new ValidatorHost({packages: mockedPackages})
+
+    expect(
+      validator.validate(['npm'], {
+        emptyHostname: true
+      })
+    ).toEqual({
+      type: 'success',
+      errors: []
+    })
+  })
+
+  it('validator should return errors if emptyHostnames are not allowed', () => {
+    const mockedPackages = {
+      '@babel/code-frame': {
+        resolved: 'github:XhmikosR/metalsmith-permalinks#master'
+      }
+    }
+    const validator = new ValidatorHost({packages: mockedPackages})
+
+    expect(
+      validator.validate(['npm'], {
+        emptyHostname: false
+      })
+    ).toEqual({
+      type: 'error',
+      errors: [
+        {
+          message: `detected invalid host(s) for package: @babel/code-frame\n    expected: registry.npmjs.org\n    actual: \n`,
+          package: '@babel/code-frame'
+        }
+      ]
+    })
+  })
 })

--- a/packages/lockfile-lint-api/src/validators/ValidateHost.js
+++ b/packages/lockfile-lint-api/src/validators/ValidateHost.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const {URL} = require('url')
+const debug = require('debug')('lockfile-lint-api')
 const PackageError = require('../common/PackageError')
 const {REGISTRY} = require('../common/constants')
 
@@ -13,7 +14,7 @@ module.exports = class ValidateHost {
     this.packages = packages
   }
 
-  validate (hosts) {
+  validate (hosts, options) {
     if (!Array.isArray(hosts)) {
       throw new Error('validate method requires an array')
     }
@@ -37,13 +38,16 @@ module.exports = class ValidateHost {
       })
 
       if (allowedHosts.indexOf(packageResolvedURL.host) === -1) {
-        // throw new Error(`detected invalid origin for package: ${packageName}`)
-        validationResult.errors.push({
-          message: `detected invalid host(s) for package: ${packageName}\n    expected: ${allowedHosts}\n    actual: ${
-            packageResolvedURL.host
-          }\n`,
-          package: packageName
-        })
+        if (!packageResolvedURL.host && options && options.emptyHostname) {
+          debug(`detected empty hostname but allowing because emptyHostname is not false`)
+        } else {
+          validationResult.errors.push({
+            message: `detected invalid host(s) for package: ${packageName}\n    expected: ${allowedHosts}\n    actual: ${
+              packageResolvedURL.host
+            }\n`,
+            package: packageName
+          })
+        }
       }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

BREAKING CHANGE: lockfile-lint-api internal method API has changed its function
signature to allow receiving a value, and then an options object in a second
argument.



<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

Relevant issues:
- #23
- #25


<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation (if required).
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun
