### PR TITLE
docs: fix casing of ParseLockfile in example code for lockfile-lint-api

### DIFF
--- a/packages/lockfile-lint-api/README.md
+++ b/packages/lockfile-lint-api/README.md
@@ -108,16 +108,16 @@ console.log(result)
 # Example
 
 ```js
-const {ValidateHost, ParseLockFile} = require('lockfile-lint-api')
+const {ValidateHost, ParseLockfile} = require('lockfile-lint-api')
 
 // path to the lockfile
-const yarnLockFilePath = '/path/to/my/yarn.lock'
+const yarnLockfilePath = '/path/to/my/yarn.lock'
 const options = {
-  lockfilePath: yarnLockFilePath
+  lockfilePath: yarnLockfilePath
 }
 
 // instantiate a new parser with options object
-const parser = new ParseLockFile(options)
+const parser = new ParseLockfile(options)
 
 // read the file synchronously and parses it
 // providing back an object that is compatible


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix the example code for `lockfile-lint-api`. As it currently is, it fails because the casing of `ParseLockfile` is incorrect in the example. Seems the docs weren't updated after the casing change occurred in the project.

## Description

Change casing from `ParseLockFile` to `ParseLockfile`
<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue
closes #37 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I added a picture of a cute animal cause it's fun

![baby_yoda](https://user-images.githubusercontent.com/12915163/71380031-bf6d6e80-259b-11ea-8320-04a8cbcbfacf.jpeg)
