### PR TITLE
fix(validators): skip packages with no resolved field

### DIFF
--- a/packages/lockfile-lint-api/__tests__/validators.host.test.js
+++ b/packages/lockfile-lint-api/__tests__/validators.host.test.js
@@ -195,4 +195,18 @@ describe('Validator: Host', () => {
       ]
     })
   })
+
+  it('validator should not throw if package has no `resolved` field', () => {
+    const mockedPackages = {
+      '@babel/code-frame': {
+        resolved: 'https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz'
+      },
+      meow: {}
+    }
+    const validator = new ValidatorHost({packages: mockedPackages})
+
+    expect(() => {
+      validator.validate(['npm'])
+    }).not.toThrow()
+  })
 })

--- a/packages/lockfile-lint-api/__tests__/validators.https.test.js
+++ b/packages/lockfile-lint-api/__tests__/validators.https.test.js
@@ -70,4 +70,22 @@ describe('Validator: HTTPS', () => {
 
     expect(() => validator.validate(['npm'])).toThrow(PackageError)
   })
+
+  it('validator should succeed if package has no `resolved` field', () => {
+    const mockedPackages = {
+      '@babel/code-frame': {
+        resolved: 'https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz'
+      },
+      meow: {},
+      '@babel/generator': {
+        resolved: 'https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz'
+      }
+    }
+
+    const validator = new ValidatorHTTPS({packages: mockedPackages})
+    expect(validator.validate()).toEqual({
+      type: 'success',
+      errors: []
+    })
+  })
 })

--- a/packages/lockfile-lint-api/__tests__/validators.scheme.test.js
+++ b/packages/lockfile-lint-api/__tests__/validators.scheme.test.js
@@ -80,4 +80,21 @@ describe('Validator: Protocol', () => {
 
     expect(() => validator.validate(['npm'])).toThrow(PackageError)
   })
+
+  it('validator should succeed if package has no `resolved` field', () => {
+    const mockedPackages = {
+      '@babel/code-frame': {
+        resolved: 'https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz'
+      },
+      meow: {},
+      '@babel/generator': {
+        resolved: 'git+ssh://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz'
+      }
+    }
+    const validator = new ValidatorScheme({packages: mockedPackages})
+    expect(validator.validate(['https:', 'git+ssh:'])).toEqual({
+      type: 'success',
+      errors: []
+    })
+  })
 })

--- a/packages/lockfile-lint-api/src/validators/ValidateHost.js
+++ b/packages/lockfile-lint-api/src/validators/ValidateHost.js
@@ -25,6 +25,10 @@ module.exports = class ValidateHost {
     }
 
     for (const [packageName, packageMetadata] of Object.entries(this.packages)) {
+      if (!('resolved' in packageMetadata)) {
+        continue
+      }
+
       let packageResolvedURL = {}
       try {
         packageResolvedURL = new URL(packageMetadata.resolved)

--- a/packages/lockfile-lint-api/src/validators/ValidateHttps.js
+++ b/packages/lockfile-lint-api/src/validators/ValidateHttps.js
@@ -21,6 +21,10 @@ module.exports = class ValidateHttps {
     }
 
     for (const [packageName, packageMetadata] of Object.entries(this.packages)) {
+      if (!('resolved' in packageMetadata)) {
+        continue
+      }
+
       let packageResolvedURL = {}
       try {
         packageResolvedURL = new URL(packageMetadata.resolved)

--- a/packages/lockfile-lint-api/src/validators/ValidateScheme.js
+++ b/packages/lockfile-lint-api/src/validators/ValidateScheme.js
@@ -23,6 +23,10 @@ module.exports = class ValidateProtocol {
     }
 
     for (const [packageName, packageMetadata] of Object.entries(this.packages)) {
+      if (!('resolved' in packageMetadata)) {
+        continue
+      }
+
       let packageResolvedURL = {}
       try {
         packageResolvedURL = new URL(packageMetadata.resolved)


### PR DESCRIPTION
Prevent URL-based validators (Host, Scheme or HTTPS) throwing errors when no `resolved` field exists for the package.

fix #42

<!--- Provide a general summary of your changes in the Title above -->

## Description
`ValidateHost`, `ValidateHttps` and `ValidateScheme` are updated to skip validation for any packages which don't have a `resolved` field in the lock-file.
<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue
https://github.com/lirantal/lockfile-lint/issues/42
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Some package entries have no `resolved` field, for example those installed from the local filesystem. For these packages, protocol, scheme and host validation should be skipped completely as there is no external source to check, but the validators are currently trying to parse a non-existent URL which results in a validation failure.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
New tests added to the `validateHost`, `validateHttps` and `validateScheme` specs to reflect the expected behaviour; tests failed before changes, and pass afterwards.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I added a picture of a cute animal cause it's fun

![Baby-Goose-Gosling-10](https://user-images.githubusercontent.com/3180526/72539118-bc9e2a80-3876-11ea-8170-8f84c42eb289.jpg)
