### PR TITLE
docs(lockfile-lint-api): add note about validation for local packages

### DIFF
--- a/packages/lockfile-lint-api/README.md
+++ b/packages/lockfile-lint-api/README.md
@@ -36,11 +36,13 @@ npm install --save lockfile-lint-api
 
 The following lockfile validators are supported
 
-| Validator API   | description                                                                     | implemented |
-| --------------  | ------------------------------------------------------------------------------- | ----------- |
-| ValidateHttps   | validates the use of HTTPS as protocol schema for all resources                 | ✅          |
-| ValidateHost    | validates a whitelist of allowed hosts to be used for resources in the lockfile | ✅          |
-| ValidateScheme  | validates a whitelist of allowed URI schemes to be used for hosts               | ✅          |
+| Validator API  | description                                                                     | implemented |
+| -------------- | ------------------------------------------------------------------------------- | ----------- |
+| ValidateHttps  | validates the use of HTTPS as protocol schema for all resources                 | ✅          |
+| ValidateHost   | validates a whitelist of allowed hosts to be used for resources in the lockfile | ✅          |
+| ValidateScheme | validates a whitelist of allowed URI schemes to be used for hosts               | ✅          |
+
+**NOTE:** package entries without a `resolved` field (for example, those installed from the local filesystem) will automatically pass all url-based validators.
 
 ## Success and failures
 


### PR DESCRIPTION
Adds a note to the Validators table making it clear that URL-based validation will succeed for
entries which lack a `resolved` field.

<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a note to the Validators table making it clear that URL-based validation will succeed for
entries which lack a `resolved` field.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue
https://github.com/lirantal/lockfile-lint/issues/42
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Issue has been fixed by https://github.com/lirantal/lockfile-lint/issues/43, but the change in behaviour warrants an update to the documentation.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
N/A
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun

^ one cute animal picture per week is probably sufficient!
