### PR TITLE
Remove outdated "only yarn is supported" note

### DIFF
--- a/packages/lockfile-lint-api/README.md
+++ b/packages/lockfile-lint-api/README.md
@@ -20,8 +20,6 @@
 
 Lints an npm or yarn lockfile to analyze and detect issues
 
-NOTE: currently only yarn's `yarn.lock` is supported. PRs to support npm's `package-lock.json` are welcome 🤗
-
 # Install
 
 ```bash


### PR DESCRIPTION
https://github.com/lirantal/lockfile-lint/issues/45

:goat: 
