### PR TITLE
fix(lockfile-lint): fixed failing tests depending on user locale

### DIFF
--- a/packages/lockfile-lint/src/cli.js
+++ b/packages/lockfile-lint/src/cli.js
@@ -46,6 +46,7 @@ const argv = yargs
   .example(
     'lockfile-lint --path yarn.lock --allowed-schemes "https:" "git+ssh:" --allowed-hosts npm yarn verdaccio'
   )
-  .epilogue('curated by Liran Tal at https://github.com/lirantal/lockfile-lint').argv
+  .epilogue('curated by Liran Tal at https://github.com/lirantal/lockfile-lint')
+  .detectLocale(false).argv
 
 module.exports = argv


### PR DESCRIPTION
## Description

Made the tests not fail if the user locale isn't the default one (en).
This issue occurred because yargs detects the locale to output things.

## Types of changes

Disabled the locale detection when configuring yargs.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

Fix #41

## Motivation and Context

I wanted to play with this great package but the tests didn't pass.

## How Has This Been Tested?

I cloned the project, installed the packages' dependencies and launched the tests. They failed.
I did the fix and checked the tests passed.

## Screenshots (if appropriate):

## Checklist:

- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed.
- [X] I added a picture of a cute animal cause it's fun

![](https://50ansdecinema.files.wordpress.com/2010/12/gizmo-gremlins.jpeg)