### PR TITLE
fix(api): lint all dependencies in package-lock

### DIFF
--- a/packages/lockfile-lint-api/__tests__/parseNpmLockfile.test.js
+++ b/packages/lockfile-lint-api/__tests__/parseNpmLockfile.test.js
@@ -17,8 +17,8 @@ describe('ParseLockfile Npm', () => {
     expect(lockfile.type).toEqual('success')
     expect(lockfile.object).toEqual(
       expect.objectContaining({
-        'debug@4.1.1': expect.any(Object),
-        'ms@2.1.2': expect.any(Object)
+        'debug@4.1.1-031b0fadad70d901aa76ca1028682c7fc8ed370c': expect.any(Object),
+        'ms@2.1.2-d6934ce87f6e568c4f5d6d9f6e5c5697992e7b91': expect.any(Object)
       })
     )
   })
@@ -35,10 +35,10 @@ describe('ParseLockfile Npm', () => {
     expect(lockfile.type).toEqual('success')
     expect(lockfile.object).toEqual(
       expect.objectContaining({
-        'debug@4.1.1': expect.any(Object),
-        'ms@2.1.2': expect.any(Object),
-        'ms@2.0.0': expect.any(Object),
-        'escape-html@1.0.3': expect.any(Object)
+        'debug@4.1.1-031b0fadad70d901aa76ca1028682c7fc8ed370c': expect.any(Object),
+        'ms@2.1.2-d6934ce87f6e568c4f5d6d9f6e5c5697992e7b91': expect.any(Object),
+        'ms@2.0.0-e3988f0b9b049286d39bee2b87cda1737adf1ba7': expect.any(Object),
+        'escape-html@1.0.3-541618a9ecf9b6e94c9131aec4590d01a5b0e720': expect.any(Object)
       })
     )
   })

--- a/packages/lockfile-lint-api/__tests__/validators.host.test.js
+++ b/packages/lockfile-lint-api/__tests__/validators.host.test.js
@@ -1,5 +1,4 @@
 const ValidatorHost = require('../src/validators/ValidateHost')
-const PackageError = require('../src/common/PackageError')
 
 describe('Validator: Host', () => {
   it('validator should throw an error when provided a string', () => {
@@ -142,17 +141,6 @@ describe('Validator: Host', () => {
         }
       ]
     })
-  })
-
-  it('validator should throw a descriptive error when one is encounterd in a package', () => {
-    const mockedPackages = {
-      '@babel/code-frame': {
-        resolved: 'debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791'
-      }
-    }
-    const validator = new ValidatorHost({packages: mockedPackages})
-
-    expect(() => validator.validate(['npm'])).toThrow(PackageError)
   })
 
   it('validator should not throw if emptyHostnames are allowed', () => {

--- a/packages/lockfile-lint-api/__tests__/validators.https.test.js
+++ b/packages/lockfile-lint-api/__tests__/validators.https.test.js
@@ -1,5 +1,4 @@
 const ValidatorHTTPS = require('../src/validators/ValidateHttps')
-const PackageError = require('../src/common/PackageError')
 
 describe('Validator: HTTPS', () => {
   it('validator should throw an error when provided a string', () => {
@@ -58,17 +57,6 @@ describe('Validator: HTTPS', () => {
       type: 'success',
       errors: []
     })
-  })
-
-  it('validator should throw a descriptive error when one is encounterd in a package', () => {
-    const mockedPackages = {
-      '@babel/code-frame': {
-        resolved: 'debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791'
-      }
-    }
-    const validator = new ValidatorHTTPS({packages: mockedPackages})
-
-    expect(() => validator.validate(['npm'])).toThrow(PackageError)
   })
 
   it('validator should succeed if package has no `resolved` field', () => {

--- a/packages/lockfile-lint-api/__tests__/validators.scheme.test.js
+++ b/packages/lockfile-lint-api/__tests__/validators.scheme.test.js
@@ -1,5 +1,4 @@
 const ValidatorScheme = require('../src/validators/ValidateScheme')
-const PackageError = require('../src/common/PackageError')
 
 describe('Validator: Protocol', () => {
   it('validator should throw an error when provided a string', () => {
@@ -68,17 +67,6 @@ describe('Validator: Protocol', () => {
       type: 'success',
       errors: []
     })
-  })
-
-  it('validator should throw a descriptive error when one is encounterd in a package', () => {
-    const mockedPackages = {
-      '@babel/code-frame': {
-        resolved: 'debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791'
-      }
-    }
-    const validator = new ValidatorScheme({packages: mockedPackages})
-
-    expect(() => validator.validate(['npm'])).toThrow(PackageError)
   })
 
   it('validator should succeed if package has no `resolved` field', () => {

--- a/packages/lockfile-lint-api/package.json
+++ b/packages/lockfile-lint-api/package.json
@@ -49,7 +49,8 @@
   },
   "dependencies": {
     "@yarnpkg/lockfile": "^1.1.0",
-    "debug": "^4.1.1"
+    "debug": "^4.1.1",
+    "object-hash": "^2.0.1"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.1",

--- a/packages/lockfile-lint-api/src/ParseLockfile.js
+++ b/packages/lockfile-lint-api/src/ParseLockfile.js
@@ -129,7 +129,7 @@ class ParseLockfile {
     for (const [depName, depMetadata] of Object.entries(npmDepsTree)) {
       const depMetadataShortend = {
         version: depMetadata.version,
-        resolved: depMetadata.resolved,
+        resolved: depMetadata.resolved ? depMetadata.resolved : depMetadata.version,
         integrity: depMetadata.integrity,
         requires: depMetadata.requires
       }

--- a/packages/lockfile-lint-api/src/ParseLockfile.js
+++ b/packages/lockfile-lint-api/src/ParseLockfile.js
@@ -4,6 +4,7 @@
 const fs = require('fs')
 const path = require('path')
 const yarnLockfileParser = require('@yarnpkg/lockfile')
+const hash = require('object-hash')
 const {ParsingError, ERROR_MESSAGES} = require('./common/ParsingError')
 const {
   NO_OPTIONS,
@@ -124,26 +125,26 @@ class ParseLockfile {
     }
   }
 
-  _flattenNpmDepsTree (npmDepsTree) {
-    let flattenedDepTree = {}
-    let flattenedNestedDepsTree = {}
+  _flattenNpmDepsTree (npmDepsTree, npmDepMap = {}) {
     for (const [depName, depMetadata] of Object.entries(npmDepsTree)) {
       const depMetadataShortend = {
         version: depMetadata.version,
-        resolved: depMetadata.resolved ? depMetadata.resolved : depMetadata.version,
+        resolved: depMetadata.resolved,
         integrity: depMetadata.integrity,
         requires: depMetadata.requires
       }
+      const hashedDepValues = hash(depMetadataShortend)
 
-      flattenedDepTree[`${depName}@${depMetadata.version}`] = depMetadataShortend
+      npmDepMap[`${depName}@${depMetadata.version}-${hashedDepValues}`] = depMetadataShortend
 
       const nestedDepsTree = depMetadata.dependencies
+
       if (nestedDepsTree && Object.keys(nestedDepsTree).length !== 0) {
-        flattenedNestedDepsTree = this._flattenNpmDepsTree(nestedDepsTree)
+        this._flattenNpmDepsTree(nestedDepsTree, npmDepMap)
       }
     }
 
-    return Object.assign({}, flattenedDepTree, flattenedNestedDepsTree)
+    return npmDepMap
   }
 }
 

--- a/packages/lockfile-lint-api/src/validators/ValidateHost.js
+++ b/packages/lockfile-lint-api/src/validators/ValidateHost.js
@@ -2,7 +2,6 @@
 
 const {URL} = require('url')
 const debug = require('debug')('lockfile-lint-api')
-const PackageError = require('../common/PackageError')
 const {REGISTRY} = require('../common/constants')
 
 module.exports = class ValidateHost {
@@ -31,12 +30,10 @@ module.exports = class ValidateHost {
 
       let packageResolvedURL = {}
 
-      if (packageMetadata.resolved) {
-        try {
-          packageResolvedURL = new URL(packageMetadata.resolved)
-        } catch (error) {
-          throw new PackageError(packageName, error)
-        }
+      try {
+        packageResolvedURL = new URL(packageMetadata.resolved)
+      } catch (error) {
+        // swallow error (assume that the version is correct)
       }
 
       const allowedHosts = hosts.map(hostValue => {

--- a/packages/lockfile-lint-api/src/validators/ValidateHost.js
+++ b/packages/lockfile-lint-api/src/validators/ValidateHost.js
@@ -30,10 +30,13 @@ module.exports = class ValidateHost {
       }
 
       let packageResolvedURL = {}
-      try {
-        packageResolvedURL = new URL(packageMetadata.resolved)
-      } catch (error) {
-        throw new PackageError(packageName, error)
+
+      if (packageMetadata.resolved) {
+        try {
+          packageResolvedURL = new URL(packageMetadata.resolved)
+        } catch (error) {
+          throw new PackageError(packageName, error)
+        }
       }
 
       const allowedHosts = hosts.map(hostValue => {

--- a/packages/lockfile-lint-api/src/validators/ValidateHttps.js
+++ b/packages/lockfile-lint-api/src/validators/ValidateHttps.js
@@ -26,10 +26,13 @@ module.exports = class ValidateHttps {
       }
 
       let packageResolvedURL = {}
-      try {
-        packageResolvedURL = new URL(packageMetadata.resolved)
-      } catch (error) {
-        throw new PackageError(packageName, error)
+
+      if (packageMetadata.resolved) {
+        try {
+          packageResolvedURL = new URL(packageMetadata.resolved)
+        } catch (error) {
+          throw new PackageError(packageName, error)
+        }
       }
 
       if (packageResolvedURL.protocol !== HTTPS_PROTOCOL) {

--- a/packages/lockfile-lint-api/src/validators/ValidateHttps.js
+++ b/packages/lockfile-lint-api/src/validators/ValidateHttps.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const {URL} = require('url')
-const PackageError = require('../common/PackageError')
 
 const HTTPS_PROTOCOL = 'https:'
 
@@ -27,12 +26,10 @@ module.exports = class ValidateHttps {
 
       let packageResolvedURL = {}
 
-      if (packageMetadata.resolved) {
-        try {
-          packageResolvedURL = new URL(packageMetadata.resolved)
-        } catch (error) {
-          throw new PackageError(packageName, error)
-        }
+      try {
+        packageResolvedURL = new URL(packageMetadata.resolved)
+      } catch (error) {
+        // swallow error (assume that the version is correct)
       }
 
       if (packageResolvedURL.protocol !== HTTPS_PROTOCOL) {

--- a/packages/lockfile-lint-api/src/validators/ValidateScheme.js
+++ b/packages/lockfile-lint-api/src/validators/ValidateScheme.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const {URL} = require('url')
-const PackageError = require('../common/PackageError')
 
 module.exports = class ValidateProtocol {
   constructor ({packages} = {}) {
@@ -29,12 +28,10 @@ module.exports = class ValidateProtocol {
 
       let packageResolvedURL = {}
 
-      if (packageMetadata.resolved) {
-        try {
-          packageResolvedURL = new URL(packageMetadata.resolved)
-        } catch (error) {
-          throw new PackageError(packageName, error)
-        }
+      try {
+        packageResolvedURL = new URL(packageMetadata.resolved)
+      } catch (error) {
+        // swallow error (assume that the version is correct)
       }
 
       if (packageResolvedURL.protocol && schemes.indexOf(packageResolvedURL.protocol) === -1) {

--- a/packages/lockfile-lint-api/src/validators/ValidateScheme.js
+++ b/packages/lockfile-lint-api/src/validators/ValidateScheme.js
@@ -28,12 +28,16 @@ module.exports = class ValidateProtocol {
       }
 
       let packageResolvedURL = {}
-      try {
-        packageResolvedURL = new URL(packageMetadata.resolved)
-      } catch (error) {
-        throw new PackageError(packageName, error)
+
+      if (packageMetadata.resolved) {
+        try {
+          packageResolvedURL = new URL(packageMetadata.resolved)
+        } catch (error) {
+          throw new PackageError(packageName, error)
+        }
       }
-      if (schemes.indexOf(packageResolvedURL.protocol) === -1) {
+
+      if (packageResolvedURL.protocol && schemes.indexOf(packageResolvedURL.protocol) === -1) {
         // throw new Error(`detected invalid origin for package: ${packageName}`)
         validationResult.errors.push({
           message: `detected invalid scheme(s) for package: ${packageName}\n    expected: ${schemes}\n    actual: ${

--- a/packages/lockfile-lint/__tests__/main.test.js
+++ b/packages/lockfile-lint/__tests__/main.test.js
@@ -161,7 +161,7 @@ describe('Main CLI logic', () => {
         validators
       })
 
-      expect(result.validatorFailures).toEqual(2)
+      expect(result.validatorFailures).toEqual(1)
       expect(result.validatorCount).toEqual(1)
       expect(result.validatorSuccesses).toEqual(0)
     })

--- a/packages/lockfile-lint/__tests__/main.test.js
+++ b/packages/lockfile-lint/__tests__/main.test.js
@@ -161,7 +161,7 @@ describe('Main CLI logic', () => {
         validators
       })
 
-      expect(result.validatorFailures).toEqual(1)
+      expect(result.validatorFailures).toEqual(2)
       expect(result.validatorCount).toEqual(1)
       expect(result.validatorSuccesses).toEqual(0)
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -7229,6 +7229,11 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
+object-hash@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.0.1.tgz#cef18a0c940cc60aa27965ecf49b782cbf101d96"
+  integrity sha512-HgcGMooY4JC2PBt9sdUdJ6PMzpin+YtY3r/7wg0uTifP+HJWW8rammseSEHuyt0UeShI183UGssCJqm1bJR7QA==
+
 object-keys@^1.0.12:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"


### PR DESCRIPTION
Will not override in the object if there is a matching dep and version
and will lint all the dependencies of dependencies.

Fixes #49

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/lirantal/lockfile-lint/issues/49

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

It solved the issue where if multiple dependencies had the same subdependencies (name and version) only one was added to the object. This was an issue if the first one was corrupt but the last one was fine, it would not be caught.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->

* Manually tested locally
* All unit tests are passing

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun
