### PR TITLE
fix(validators): only validating when URL is present

### DIFF
--- a/packages/lockfile-lint-api/src/validators/ValidateHttps.js
+++ b/packages/lockfile-lint-api/src/validators/ValidateHttps.js
@@ -28,17 +28,17 @@ module.exports = class ValidateHttps {
 
       try {
         packageResolvedURL = new URL(packageMetadata.resolved)
+
+        if (packageResolvedURL.protocol !== HTTPS_PROTOCOL) {
+          validationResult.errors.push({
+            message: `detected invalid protocol for package: ${packageName}\n    expected: ${HTTPS_PROTOCOL}\n    actual: ${
+              packageResolvedURL.protocol
+            }\n`,
+            package: packageName
+          })
+        }
       } catch (error) {
         // swallow error (assume that the version is correct)
-      }
-
-      if (packageResolvedURL.protocol !== HTTPS_PROTOCOL) {
-        validationResult.errors.push({
-          message: `detected invalid protocol for package: ${packageName}\n    expected: ${HTTPS_PROTOCOL}\n    actual: ${
-            packageResolvedURL.protocol
-          }\n`,
-          package: packageName
-        })
       }
     }
 

--- a/packages/lockfile-lint-api/src/validators/ValidateScheme.js
+++ b/packages/lockfile-lint-api/src/validators/ValidateScheme.js
@@ -30,18 +30,17 @@ module.exports = class ValidateProtocol {
 
       try {
         packageResolvedURL = new URL(packageMetadata.resolved)
+
+        if (packageResolvedURL.protocol && schemes.indexOf(packageResolvedURL.protocol) === -1) {
+          validationResult.errors.push({
+            message: `detected invalid scheme(s) for package: ${packageName}\n    expected: ${schemes}\n    actual: ${
+              packageResolvedURL.protocol
+            }\n`,
+            package: packageName
+          })
+        }
       } catch (error) {
         // swallow error (assume that the version is correct)
-      }
-
-      if (packageResolvedURL.protocol && schemes.indexOf(packageResolvedURL.protocol) === -1) {
-        // throw new Error(`detected invalid origin for package: ${packageName}`)
-        validationResult.errors.push({
-          message: `detected invalid scheme(s) for package: ${packageName}\n    expected: ${schemes}\n    actual: ${
-            packageResolvedURL.protocol
-          }\n`,
-          package: packageName
-        })
       }
     }
 


### PR DESCRIPTION
## Description

a regression introduced via PR #53 due to flat package list
now being all-inclusive of packages, some of which have no
protocol or URL to resolve to (the nested deps) and so the
validators failed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

Fixes #58 

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## How Has This Been Tested?

Missing from this PR is a set of unit tests to cover the error and will need to follow-up on.
