### PR TITLE
fix(cli): conflicting arguments will error

### DIFF
--- a/packages/lockfile-lint/__tests__/cli.test.js
+++ b/packages/lockfile-lint/__tests__/cli.test.js
@@ -50,10 +50,16 @@ describe('CLI tests', () => {
     })
 
     process.stdout.on('close', exit => {
-      expect(output.indexOf('detected invalid protocol for package: debug@^4.1.1\n    expected: https:\n    actual: http:\n')).not.toBe(
-        -1
-      )
-      expect(output.indexOf('detected invalid protocol for package: ms@^2.1.1\n    expected: https:\n    actual: http:\n')).not.toBe(-1)
+      expect(
+        output.indexOf(
+          'detected invalid protocol for package: debug@^4.1.1\n    expected: https:\n    actual: http:\n'
+        )
+      ).not.toBe(-1)
+      expect(
+        output.indexOf(
+          'detected invalid protocol for package: ms@^2.1.1\n    expected: https:\n    actual: http:\n'
+        )
+      ).not.toBe(-1)
       expect(output.indexOf('error: command failed with exit code 1')).not.toBe(-1)
       done()
     })
@@ -70,6 +76,28 @@ describe('CLI tests', () => {
 
     process.on('close', exitCode => {
       expect(exitCode).toBe(1)
+      done()
+    })
+  })
+
+  test('Providing conflicting arguments should display an error', done => {
+    const process = childProcess.spawn(cliExecPath, [
+      '--type',
+      'yarn',
+      '--path',
+      '__tests__/fixtures/yarn-only-http.lock',
+      '--validate-https',
+      '--allowed-schemes',
+      'https:'
+    ])
+
+    let output = ''
+    process.stderr.on('data', chunk => {
+      output += chunk
+    })
+
+    process.stderr.on('close', _ => {
+      expect(output.indexOf('Arguments o and validate-https are mutually exclusive')).not.toBe(-1)
       done()
     })
   })

--- a/packages/lockfile-lint/src/cli.js
+++ b/packages/lockfile-lint/src/cli.js
@@ -38,7 +38,8 @@ const argv = yargs
     o: {
       alias: ['allowed-schemes'],
       type: 'array',
-      describe: 'validates a whitelist of allowed schemes to be used for resources in the lockfile'
+      describe: 'validates a whitelist of allowed schemes to be used for resources in the lockfile',
+      conflicts: ['validate-https', 's']
     }
   })
   .example('lockfile-lint --path yarn.lock --validate-https')


### PR DESCRIPTION
## Description

When incompatible CLI arguments are provided they shouldn't just be ignored and lead to failure but rather a proper message should be provided to users.

## Types of changes

Detecting the conflicting use of both `--allowed-schemes` and `--validate-https` and error'ing out with specifying that only one of those should be used.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

Fixes #63 

## Motivation and Context

Provides a better CLI experience for users.

## How Has This Been Tested?

Added a CLI test.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/316371/74090711-3660b700-4ab7-11ea-866c-e35f805b08a8.png)


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun
