### PR TITLE
chore: switch to `string.includes`

### DIFF
--- a/packages/lockfile-lint-api/src/validators/ValidateHost.js
+++ b/packages/lockfile-lint-api/src/validators/ValidateHost.js
@@ -38,7 +38,7 @@ module.exports = class ValidateHost {
           return REGISTRY[hostValue] ? REGISTRY[hostValue] : hostValue
         })
 
-        if (allowedHosts.indexOf(packageResolvedURL.host) === -1) {
+        if (!allowedHosts.includes(packageResolvedURL.host)) {
           if (!packageResolvedURL.host && options && options.emptyHostname) {
             debug(`detected empty hostname but allowing because emptyHostname is not false`)
           } else {

--- a/packages/lockfile-lint-api/src/validators/ValidateScheme.js
+++ b/packages/lockfile-lint-api/src/validators/ValidateScheme.js
@@ -31,7 +31,7 @@ module.exports = class ValidateProtocol {
       try {
         packageResolvedURL = new URL(packageMetadata.resolved)
 
-        if (packageResolvedURL.protocol && schemes.indexOf(packageResolvedURL.protocol) === -1) {
+        if (packageResolvedURL.protocol && !schemes.includes(packageResolvedURL.protocol)) {
           validationResult.errors.push({
             message: `detected invalid scheme(s) for package: ${packageName}\n    expected: ${schemes}\n    actual: ${
               packageResolvedURL.protocol

--- a/packages/lockfile-lint/__tests__/cli.test.js
+++ b/packages/lockfile-lint/__tests__/cli.test.js
@@ -14,9 +14,9 @@ describe('CLI tests', () => {
     })
 
     process.stdout.on('close', () => {
-      expect(output.indexOf('Usage:')).not.toBe(-1)
-      expect(output.indexOf('Options:')).not.toBe(-1)
-      expect(output.indexOf('Examples:')).not.toBe(-1)
+      expect(output).toContain('Usage:')
+      expect(output).toContain('Options:')
+      expect(output).toContain('Examples:')
       done()
     })
   })
@@ -30,7 +30,7 @@ describe('CLI tests', () => {
     })
 
     process.stdout.on('close', () => {
-      expect(output.indexOf('Missing required argument: p')).not.toBe(-1)
+      expect(output).toContain('Missing required argument: p')
       done()
     })
   })
@@ -50,11 +50,13 @@ describe('CLI tests', () => {
     })
 
     process.stdout.on('close', exit => {
-      expect(output.indexOf('detected invalid protocol for package: debug@^4.1.1\n    expected: https:\n    actual: http:\n')).not.toBe(
-        -1
+      expect(output).toContain(
+        'detected invalid protocol for package: debug@^4.1.1\n    expected: https:\n    actual: http:\n'
       )
-      expect(output.indexOf('detected invalid protocol for package: ms@^2.1.1\n    expected: https:\n    actual: http:\n')).not.toBe(-1)
-      expect(output.indexOf('error: command failed with exit code 1')).not.toBe(-1)
+      expect(output).toContain(
+        'detected invalid protocol for package: ms@^2.1.1\n    expected: https:\n    actual: http:\n'
+      )
+      expect(output).toContain('error: command failed with exit code 1')
       done()
     })
   })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- switch to `string.includes` 
- improve usage of jest assertions

<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation (if required).
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun

---

@lirantal I can't test this being I'm on Windows and tests just fail for master too. :/