### PR TITLE
feat(cli): error on conflicting options

### DIFF
--- a/packages/lockfile-lint/__tests__/cli.test.js
+++ b/packages/lockfile-lint/__tests__/cli.test.js
@@ -50,10 +50,16 @@ describe('CLI tests', () => {
     })
 
     process.stdout.on('close', exit => {
-      expect(output.indexOf('detected invalid protocol for package: debug@^4.1.1\n    expected: https:\n    actual: http:\n')).not.toBe(
-        -1
-      )
-      expect(output.indexOf('detected invalid protocol for package: ms@^2.1.1\n    expected: https:\n    actual: http:\n')).not.toBe(-1)
+      expect(
+        output.indexOf(
+          'detected invalid protocol for package: debug@^4.1.1\n    expected: https:\n    actual: http:\n'
+        )
+      ).not.toBe(-1)
+      expect(
+        output.indexOf(
+          'detected invalid protocol for package: ms@^2.1.1\n    expected: https:\n    actual: http:\n'
+        )
+      ).not.toBe(-1)
       expect(output.indexOf('error: command failed with exit code 1')).not.toBe(-1)
       done()
     })
@@ -70,6 +76,28 @@ describe('CLI tests', () => {
 
     process.on('close', exitCode => {
       expect(exitCode).toBe(1)
+      done()
+    })
+  })
+
+  test('Providing conflicting arguments should display an error', done => {
+    const process = childProcess.spawn(cliExecPath, [
+      '--type',
+      'yarn',
+      '--path',
+      '__tests__/fixtures/yarn-only-http.lock',
+      '--validate-https',
+      '--allowed-schemes',
+      'https:'
+    ])
+
+    let output = ''
+    process.stderr.on('data', chunk => {
+      output += chunk
+    })
+
+    process.stderr.on('close', _ => {
+      expect(output.indexOf('Arguments o and validate-https are mutually exclusive')).not.toBe(-1)
       done()
     })
   })

--- a/packages/lockfile-lint/src/cli.js
+++ b/packages/lockfile-lint/src/cli.js
@@ -38,7 +38,8 @@ const argv = yargs
     o: {
       alias: ['allowed-schemes'],
       type: 'array',
-      describe: 'validates a whitelist of allowed schemes to be used for resources in the lockfile'
+      describe: 'validates a whitelist of allowed schemes to be used for resources in the lockfile',
+      conflicts: ['validate-https', 's']
     }
   })
   .example('lockfile-lint --path yarn.lock --validate-https')


### PR DESCRIPTION
## Description

BREAKING CHANGE: CLI may show an error when arguments conflict
    and the order of short and long options was reversed to be
    more descriptive on CLI options errors.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

#64 
