### PR TITLE
fix(hostvalidator): support full urls for host

### DIFF
--- a/packages/lockfile-lint-api/__tests__/validators.host.test.js
+++ b/packages/lockfile-lint-api/__tests__/validators.host.test.js
@@ -96,6 +96,26 @@ describe('Validator: Host', () => {
     }
 
     const validator = new ValidatorHost({packages: mockedPackages})
+    expect(validator.validate(['registry.verdaccio.org'])).toEqual({
+      type: 'success',
+      errors: []
+    })
+  })
+
+  it('validator should succeed if all resources are matching a host address but input is a full URL', () => {
+    const mockedPackages = {
+      '@babel/code-frame': {
+        resolved: 'https://registry.verdaccio.org/@babel/code-frame/-/code-frame-7.0.0.tgz'
+      },
+      meow: {
+        resolved: 'https://registry.verdaccio.org/meow/-/meow-4.0.1.tgz'
+      },
+      '@babel/generator': {
+        resolved: 'https://registry.verdaccio.org/@babel/generator/-/generator-7.4.4.tgz'
+      }
+    }
+
+    const validator = new ValidatorHost({packages: mockedPackages})
     expect(validator.validate(['https://registry.verdaccio.org'])).toEqual({
       type: 'success',
       errors: []

--- a/packages/lockfile-lint-api/src/validators/ValidateHost.js
+++ b/packages/lockfile-lint-api/src/validators/ValidateHost.js
@@ -30,9 +30,18 @@ module.exports = class ValidateHost {
 
       try {
         const packageResolvedURL = new URL(packageMetadata.resolved)
-        const allowedHosts = hosts.map(hostValue => {
+        const allowedHosts = hosts.map(allowedHost => {
           // eslint-disable-next-line security/detect-object-injection
-          return REGISTRY[hostValue] ? REGISTRY[hostValue] : hostValue
+          const host = REGISTRY[allowedHost] ? REGISTRY[allowedHost] : allowedHost
+          let hostValue
+          try {
+            const parsedHost = new URL(host)
+            hostValue = parsedHost.host
+          } catch (error) {
+            hostValue = host
+          }
+
+          return hostValue
         })
         const isPassing = allowedHosts.includes(packageResolvedURL.host)
         if (!isPassing) {


### PR DESCRIPTION
## Description

Support URLs provided for the host parameter by parsing them for the actual host.

- Fix breaking tests due to changes in host validator
- Attempt to parse a URL in order to capture the host for it

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
