### PR TITLE
update README example 3 to not check --validate-https

### DIFF
--- a/packages/lockfile-lint/README.md
+++ b/packages/lockfile-lint/README.md
@@ -59,7 +59,7 @@ lockfile-lint --path yarn.lock --allowed-hosts registry.yarnpkg.com --validate-h
 **Example 3**: allow the lockfile to contain packages served over github and so need to specify github.com as a host as well as the `git+https:` as a valid URI scheme
 
 ```bash
-lockfile-lint --path yarn.lock --allowed-hosts yarn github.com --validate-https --allowed-schemes "https:" "git+https:"
+lockfile-lint --path yarn.lock --allowed-hosts yarn github.com --allowed-schemes "https:" "git+https:"
 ```
 
 - `--allowed-hosts` explicitly set to match github.com as a host and specifies `yarn` as the alias for yarn's official mirror host


### PR DESCRIPTION
## Description

Validating https and using allowed-schemes is mutually exclusive, so the example needed updating in order to work.

## Types of changes

N/A - is just a chore

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

https://github.com/lirantal/lockfile-lint/issues/89