### PR TITLE
fix: support host:port syntax

### DIFF
--- a/packages/lockfile-lint-api/__tests__/validators.host.test.js
+++ b/packages/lockfile-lint-api/__tests__/validators.host.test.js
@@ -241,4 +241,38 @@ describe('Validator: Host', () => {
 
     expect(validator.validateSingle('meow', ['npm'])).toEqual(true)
   })
+
+  it('validator should succeed if resources match a host:port address as input', () => {
+    const mockedPackages = {
+      '@babel/code-frame': {
+        resolved: 'https://nexus.example.com:8089/@babel/code-frame/-/code-frame-7.0.0.tgz'
+      },
+      meow: {
+        resolved: 'https://registry.yarnpkg.com/meow/-/meow-4.0.1.tgz'
+      },
+      '@babel/generator': {
+        resolved: 'https://nexus.example.com:8089/@babel/generator/-/generator-7.4.4.tgz'
+      }
+    }
+
+    const validator = new ValidatorHost({packages: mockedPackages})
+    expect(validator.validate(['yarn', 'nexus.example.com:8089'])).toEqual({
+      type: 'success',
+      errors: []
+    })
+  })
+
+  it('validator should succeed if a resource matches a host:port address as input', () => {
+    const mockedPackages = {
+      '@babel/code-frame': {
+        resolved: 'https://nexus.example.com:8089/@babel/code-frame/-/code-frame-7.0.0.tgz'
+      }
+    }
+
+    const validator = new ValidatorHost({packages: mockedPackages})
+    expect(validator.validate(['nexus.example.com:8089'])).toEqual({
+      type: 'success',
+      errors: []
+    })
+  })
 })

--- a/packages/lockfile-lint-api/src/validators/ValidateHost.js
+++ b/packages/lockfile-lint-api/src/validators/ValidateHost.js
@@ -33,16 +33,20 @@ module.exports = class ValidateHost {
         const allowedHosts = hosts.map(allowedHost => {
           // eslint-disable-next-line security/detect-object-injection
           const host = REGISTRY[allowedHost] ? REGISTRY[allowedHost] : allowedHost
-          let hostValue
+          let hostValue = host
+
           try {
             const parsedHost = new URL(host)
-            hostValue = parsedHost.host
+            if (parsedHost.host) {
+              hostValue = parsedHost.host
+            }
           } catch (error) {
-            hostValue = host
+            debug(`failed parsing a URL object from given host value so using as is: ${host}`)
           }
 
           return hostValue
         })
+
         const isPassing = allowedHosts.includes(packageResolvedURL.host)
         if (!isPassing) {
           if (!packageResolvedURL.host && options && options.emptyHostname) {


### PR DESCRIPTION
## Description

This PR fixes the problem where a host is provided with a port, such as `mydomain.com:1234` and treats it as-is if it can't parse it. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

Fixes #93 

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
