### PR TITLE
fix: all debug under lockfile-lint namespace

### DIFF
--- a/packages/lockfile-lint/src/validators/index.js
+++ b/packages/lockfile-lint/src/validators/index.js
@@ -7,7 +7,7 @@ const {
   ValidateScheme,
   ValidateUrl
 } = require('lockfile-lint-api')
-const debug = require('debug')
+const debug = require('debug')('lockfile-lint')
 
 module.exports = {
   ValidateHostManager,
@@ -17,8 +17,8 @@ module.exports = {
 }
 
 function ValidateSchemeManager ({path, type, validatorValues, validatorOptions}) {
-  debug('validate-scheme-manager')(
-    `invoked with validator options: ${JSON.stringify(validatorValues)}`
+  debug(
+    `validate-scheme-manager invoked with validator options: ${JSON.stringify(validatorValues)}`
   )
 
   const options = {
@@ -34,9 +34,7 @@ function ValidateSchemeManager ({path, type, validatorValues, validatorOptions})
 }
 
 function ValidateHostManager ({path, type, validatorValues, validatorOptions}) {
-  debug('validate-host-manager')(
-    `invoked with validator options: ${JSON.stringify(validatorValues)}`
-  )
+  debug(`validate-host-manager invoked with validator options: ${JSON.stringify(validatorValues)}`)
 
   const options = {
     lockfilePath: path,
@@ -66,9 +64,7 @@ function ValidateHostManager ({path, type, validatorValues, validatorOptions}) {
 }
 
 function ValidateHttpsManager ({path, type, validatorValues, validatorOptions}) {
-  debug('validate-host-manager')(
-    `invoked with validator options: ${JSON.stringify(validatorValues)}`
-  )
+  debug(`validate-host-manager invoked with validator options: ${JSON.stringify(validatorValues)}`)
 
   const options = {
     lockfilePath: path,
@@ -83,9 +79,7 @@ function ValidateHttpsManager ({path, type, validatorValues, validatorOptions}) 
 }
 
 function ValidateUrlManager ({path, type, validatorValues, validatorOptions}) {
-  debug('validate-url-manager')(
-    `invoked with validator options: ${JSON.stringify(validatorValues)}`
-  )
+  debug(`validate-url-manager invoked with validator options: ${JSON.stringify(validatorValues)}`)
 
   const options = {
     lockfilePath: path,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Debugging for the CLI needed to enable specific DEBUG namespace to see each validator. Instead, put them all under the same "lockfile-lint" namespace so that it won't be hard to find the keys.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
