### PR TITLE
102 fix empty dependencies

### DIFF
--- a/packages/lockfile-lint-api/src/ParseLockfile.js
+++ b/packages/lockfile-lint-api/src/ParseLockfile.js
@@ -114,7 +114,7 @@ class ParseLockfile {
       // transform original format of npm's package-json to match yarns
       // so we have a unified format to validate against
       const npmDepsTree = packageJsonParsed.dependencies
-      flattenedDepTree = this._flattenNpmDepsTree(npmDepsTree)
+      flattenedDepTree = npmDepsTree ? this._flattenNpmDepsTree(npmDepsTree) : {}
     } catch (error) {
       throw new ParsingError(PARSE_NPMLOCKFILE_FAILED, this.options.lockfilePath, error)
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
https://github.com/lirantal/lockfile-lint/issues/102 

Currently, it's calling https://github.com/lirantal/lockfile-lint/blob/d7564f8d20c9dbd4b8fc786f1d9967d7be6d6302/packages/lockfile-lint-api/src/ParseLockfile.js#L128   with 'undefined' (npmDepsTree) when there are no 'dependencies' in package-lock.json https://github.com/lirantal/lockfile-lint/blob/d7564f8d20c9dbd4b8fc786f1d9967d7be6d6302/packages/lockfile-lint-api/src/ParseLockfile.js#L116 and that causes Object.entries(npmDepsTree) to break.

<!--- Describe your changes in detail -->

Solution:

If not undefined call _flattenNpmDepsTree else set empty object

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

https://github.com/lirantal/lockfile-lint/issues/102

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Locally 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun
