### PR TITLE
fix #125 - remove debug dependency from lockfile-lint-api

### DIFF
--- a/packages/lockfile-lint-api/package.json
+++ b/packages/lockfile-lint-api/package.json
@@ -4,7 +4,7 @@
   "description": "Lint an npm or yarn lockfile to analyze and detect issues",
   "main": "index.js",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "lint": "eslint .",
@@ -49,7 +49,6 @@
   },
   "dependencies": {
     "@yarnpkg/parsers": "^3.0.0-rc.6",
-    "debug": "^4.1.1",
     "object-hash": "^2.0.1"
   },
   "devDependencies": {

--- a/packages/lockfile-lint-api/src/validators/ValidateHost.js
+++ b/packages/lockfile-lint-api/src/validators/ValidateHost.js
@@ -1,16 +1,16 @@
 'use strict'
 
-const {URL} = require('url')
-const debug = require('debug')('lockfile-lint-api')
 const {REGISTRY} = require('../common/constants')
 
+const noop = () => {}
 module.exports = class ValidateHost {
-  constructor ({packages} = {}) {
+  constructor ({packages, debug = noop} = {}) {
     if (typeof packages !== 'object') {
       throw new Error('expecting an object passed to validator constructor')
     }
 
     this.packages = packages
+    this.debug = debug
   }
 
   validate (hosts, options) {
@@ -41,7 +41,7 @@ module.exports = class ValidateHost {
               hostValue = parsedHost.host
             }
           } catch (error) {
-            debug(`failed parsing a URL object from given host value so using as is: ${host}`)
+            this.debug(`failed parsing a URL object from given host value so using as is: ${host}`)
           }
 
           return hostValue
@@ -50,7 +50,7 @@ module.exports = class ValidateHost {
         const isPassing = allowedHosts.includes(packageResolvedURL.host)
         if (!isPassing) {
           if (!packageResolvedURL.host && options && options.emptyHostname) {
-            debug(`detected empty hostname but allowing because emptyHostname is not false`)
+            this.debug(`detected empty hostname but allowing because emptyHostname is not false`)
           } else {
             validationResult.errors.push({
               message: `detected invalid host(s) for package: ${packageName}\n    expected: ${allowedHosts}\n    actual: ${

--- a/packages/lockfile-lint-api/src/validators/ValidateHttps.js
+++ b/packages/lockfile-lint-api/src/validators/ValidateHttps.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const {URL} = require('url')
-
 const HTTPS_PROTOCOL = 'https:'
 
 module.exports = class ValidateHttps {

--- a/packages/lockfile-lint-api/src/validators/ValidatePackageNames.js
+++ b/packages/lockfile-lint-api/src/validators/ValidatePackageNames.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const {URL} = require('url')
-
 module.exports = class ValidatePackageNames {
   constructor ({packages} = {}) {
     if (typeof packages !== 'object') {

--- a/packages/lockfile-lint-api/src/validators/ValidateScheme.js
+++ b/packages/lockfile-lint-api/src/validators/ValidateScheme.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const {URL} = require('url')
-
 module.exports = class ValidateProtocol {
   constructor ({packages} = {}) {
     if (typeof packages !== 'object') {

--- a/packages/lockfile-lint/package.json
+++ b/packages/lockfile-lint/package.json
@@ -6,7 +6,7 @@
     "lockfile-lint": "./bin/lockfile-lint.js"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "lint": "eslint .",

--- a/packages/lockfile-lint/src/validators/index.js
+++ b/packages/lockfile-lint/src/validators/index.js
@@ -45,7 +45,7 @@ function ValidateHostManager ({path, type, validatorValues, validatorOptions}) {
 
   const parser = new ParseLockfile(options)
   const lockfile = parser.parseSync()
-  const validator = new ValidateHost({packages: lockfile.object})
+  const validator = new ValidateHost({packages: lockfile.object, debug: require('debug')('lockfile-lint')})
   const validationResult = validator.validate(validatorValues, validatorOptions)
 
   // Check if some of the errors are for allowed URLs and filter those out


### PR DESCRIPTION
Just getting rid of a dependency that, while barely used, pulls in a bunch of requirements. Here's an overview:
```
"lockfile-lint-api>debug": {
      "builtin": {
        "tty.isatty": true,
        "util.deprecate": true,
        "util.format": true,
        "util.inspect": true
      },
      "globals": {
        "console": true,
        "document": true,
        "localStorage": true,
        "navigator": true,
        "process": true
      },
      "packages": {
        "lavamoat>@babel/highlight>chalk>supports-color": true,
        "lockfile-lint-api>debug>ms": true
      }
    },
```

This is also contributing to the progress on #123 by getting rid of tty and process requirements


BREAKING:

bumped engine to v10 to remove all `const {URL} = require('url')`


I saw semantic-release is used, so this may need to be split into two conventional commits
