### PR TITLE
feat(lockfile-lint-api): adds validation for resolved fields (#120)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ typings/
 
 # DynamoDB Local files
 .dynamodb/
+
+# vscode
+.vscode/

--- a/packages/lockfile-lint-api/README.md
+++ b/packages/lockfile-lint-api/README.md
@@ -39,6 +39,7 @@ The following lockfile validators are supported
 | ValidateHttps        | validates the use of HTTPS as protocol schema for all resources                 | ✅          |
 | ValidateHost         | validates a whitelist of allowed hosts to be used for resources in the lockfile | ✅          |
 | ValidatePackageNames | validates that the resolved URL matches the package name                        | ✅          |
+| ValidateResolved     | validates that there is a resolved URL for every package                        | ✅          |
 | ValidateScheme       | validates a whitelist of allowed URI schemes to be used for hosts               | ✅          |
 
 **NOTE:** package entries without a `resolved` field (for example, those installed from the local filesystem) will automatically pass all url-based validators.

--- a/packages/lockfile-lint-api/__tests__/validators.resolved.test.js
+++ b/packages/lockfile-lint-api/__tests__/validators.resolved.test.js
@@ -1,0 +1,64 @@
+const ValidateResolved = require('../src/validators/ValidateResolved')
+
+describe('Validator: Resolved', () => {
+  it('validator should throw an error when provided a string', () => {
+    expect(() => new ValidateResolved('ss')).toThrowError()
+  })
+
+  it('validator should throw an error when provided null', () => {
+    expect(() => new ValidateResolved(null)).toThrowError()
+  })
+
+  it('validator should throw an error when provided undefined', () => {
+    expect(() => new ValidateResolved()).toThrowError()
+  })
+
+  it('validator should throw an error when provided array', () => {
+    expect(() => new ValidateResolved(['a'])).toThrowError()
+  })
+
+  it('validator should succeed if all resource URLs are for correct packages', () => {
+    const mockedPackages = {
+      '@babel/code-frame@^0.16.0': {
+        resolved: 'https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz'
+      },
+      'meow@1.0.0': {
+        resolved: 'https://registry.npmjs.org/meow/-/meow-4.0.1.tgz'
+      },
+      '@babel/generator@3.2.1': {
+        resolved: 'https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz'
+      }
+    }
+
+    const validator = new ValidateResolved({packages: mockedPackages})
+    expect(validator.validate()).toEqual({
+      type: 'success',
+      errors: []
+    })
+  })
+
+  it('validator should fail if package has no `resolved` field', () => {
+    const mockedPackages = {
+      '@babel/code-frame@^0.16.0': {
+        resolved: 'https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz'
+      },
+      meow: {},
+      '@babel/generator@3.2.1': {}
+    }
+
+    const validator = new ValidateResolved({packages: mockedPackages})
+    expect(validator.validate()).toEqual({
+      type: 'error',
+      errors: [
+        {
+          message: 'missing resolved field for package: meow\n',
+          package: 'meow'
+        },
+        {
+          message: 'missing resolved field for package: @babel/generator\n',
+          package: '@babel/generator'
+        }
+      ]
+    })
+  })
+})

--- a/packages/lockfile-lint-api/index.js
+++ b/packages/lockfile-lint-api/index.js
@@ -3,6 +3,7 @@
 const ValidateHost = require('./src/validators/ValidateHost')
 const ValidateHttps = require('./src/validators/ValidateHttps')
 const ValidatePackageNames = require('./src/validators/ValidatePackageNames')
+const ValidateResolved = require('./src/validators/ValidateResolved')
 const ValidateScheme = require('./src/validators/ValidateScheme')
 const ValidateUrl = require('./src/validators/ValidateUrl')
 const ParseLockfile = require('./src/ParseLockfile')
@@ -12,6 +13,7 @@ module.exports = {
   ValidateHost,
   ValidateHttps,
   ValidatePackageNames,
+  ValidateResolved,
   ValidateScheme,
   ValidateUrl
 }

--- a/packages/lockfile-lint-api/src/validators/ValidateResolved.js
+++ b/packages/lockfile-lint-api/src/validators/ValidateResolved.js
@@ -1,0 +1,42 @@
+'use strict'
+
+module.exports = class ValidateResolved {
+  constructor ({packages} = {}) {
+    if (typeof packages !== 'object') {
+      throw new Error('expecting an object passed to validator constructor')
+    }
+
+    this.packages = packages
+  }
+
+  validate () {
+    let validationResult = {
+      type: 'success',
+      errors: []
+    }
+
+    for (const [packageName, packageMetadata] of Object.entries(this.packages)) {
+      if (!('resolved' in packageMetadata)) {
+        // Remove versioning info from packageName.
+        // The @ sign is the delimiter, but could also be the
+        // first character of a scoped package name.
+        // We handle this edge-case here.
+        const nameOnly = packageName.startsWith('@')
+          ? `@${packageName.slice(1).split('@')[0]}`
+          : packageName.split('@')[0]
+
+        validationResult.errors.push({
+          message: `missing resolved field for package: ${nameOnly}\n`,
+          package: nameOnly
+        })
+        continue
+      }
+    }
+
+    if (validationResult.errors.length > 0) {
+      validationResult.type = 'error'
+    }
+
+    return validationResult
+  }
+}

--- a/packages/lockfile-lint/bin/lockfile-lint.js
+++ b/packages/lockfile-lint/bin/lockfile-lint.js
@@ -41,6 +41,7 @@ const supportedValidators = new Map([
   ['allowed-hosts', 'validateHosts'],
   ['validate-https', 'validateHttps'],
   ['validate-package-names', 'ValidatePackageNames'],
+  ['validate-resolved', 'ValidateResolved'],
   ['allowed-schemes', 'validateSchemes'],
   ['allowed-urls', 'validateUrls']
 ])

--- a/packages/lockfile-lint/src/main.js
+++ b/packages/lockfile-lint/src/main.js
@@ -5,6 +5,7 @@ const {
   ValidateHostManager,
   ValidateHttpsManager,
   ValidatePackageNamesManager,
+  ValidateResolvedManager,
   ValidateSchemeManager,
   ValidateUrlManager
 } = require('../src/validators')
@@ -13,6 +14,7 @@ const validatorFunctions = new Map([
   ['validateHosts', ValidateHostManager],
   ['validateHttps', ValidateHttpsManager],
   ['ValidatePackageNames', ValidatePackageNamesManager],
+  ['ValidateResolved', ValidateResolvedManager],
   ['validateSchemes', ValidateSchemeManager],
   ['validateUrls', ValidateUrlManager]
 ])

--- a/packages/lockfile-lint/src/validators/index.js
+++ b/packages/lockfile-lint/src/validators/index.js
@@ -5,6 +5,7 @@ const {
   ParseLockfile,
   ValidateHttps,
   ValidatePackageNames,
+  ValidateResolved,
   ValidateScheme,
   ValidateUrl
 } = require('lockfile-lint-api')
@@ -14,6 +15,7 @@ module.exports = {
   ValidateHostManager,
   ValidateHttpsManager,
   ValidatePackageNamesManager,
+  ValidateResolvedManager,
   ValidateSchemeManager,
   ValidateUrlManager
 }
@@ -95,6 +97,23 @@ function ValidatePackageNamesManager ({path, type, validatorValues, validatorOpt
   const parser = new ParseLockfile(options)
   const lockfile = parser.parseSync()
   const validator = new ValidatePackageNames({packages: lockfile.object})
+
+  return validator.validate()
+}
+
+function ValidateResolvedManager ({path, type, validatorValues, validatorOptions}) {
+  debug(
+    `validate-resolved-manager invoked with validator options: ${JSON.stringify(validatorValues)}`
+  )
+
+  const options = {
+    lockfilePath: path,
+    lockfileType: type
+  }
+
+  const parser = new ParseLockfile(options)
+  const lockfile = parser.parseSync()
+  const validator = new ValidateResolved({packages: lockfile.object})
 
   return validator.validate()
 }


### PR DESCRIPTION
## Description

Adds a validator for when resolved fields are missing in lockfiles.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

#120 

## Motivation and Context

If a resolved field doesn't exist, npm may have to fetch a packument, which is a large file, and can cause timeouts in CI/CD.

## How Has This Been Tested?

I ran `yarn test` from the root, copied the existing test suite from validate package names, and got 100% coverage

## Checklist:

- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun
