### PR TITLE
fix: package names from github

### DIFF
--- a/packages/lockfile-lint-api/__tests__/validators.packageNames.test.js
+++ b/packages/lockfile-lint-api/__tests__/validators.packageNames.test.js
@@ -51,6 +51,9 @@ describe('Validator: PackageName', () => {
       },
       '@babel/generator@3.2.1': {
         resolved: 'https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz'
+      },
+      avsc: {
+        resolved: 'https://github.com/Bundlr-Network/avsc#a730cc8018b79e114b6a3381bbb57760a24c6cef'
       }
     }
 

--- a/packages/lockfile-lint-api/src/validators/ValidatePackageNames.js
+++ b/packages/lockfile-lint-api/src/validators/ValidatePackageNames.js
@@ -31,7 +31,13 @@ module.exports = class ValidatePackageNames {
           ? `@${packageName.slice(1).split('@')[0]}`
           : packageName.split('@')[0]
 
-        const expectedURLBeginning = `${packageResolvedURL.origin}/${nameOnly}`
+        let expectedURLBeginning = `${packageResolvedURL.origin}/${nameOnly}`
+        if (packageResolvedURL.origin === 'https://github.com') {
+          // Extract the github org if the package is coming from github
+          expectedURLBeginning = `${packageResolvedURL.origin}/${
+            packageResolvedURL.pathname.split('/')[1]
+          }/${nameOnly}`
+        }
 
         const isPassing = packageMetadata.resolved.startsWith(expectedURLBeginning)
         if (!isPassing) {


### PR DESCRIPTION
## Description

Some packages come from directly github - these packages fail the validate package name check

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Unit tested

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation (if required).
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun
