### PR TITLE
fix: error handling for empty yarn lock files (#158)

### DIFF
--- a/packages/lockfile-lint-api/src/ParseLockfile.js
+++ b/packages/lockfile-lint-api/src/ParseLockfile.js
@@ -21,6 +21,9 @@ const {
  * @return boolean
  */
 function checkSampleContent (lockfile, isYarnBerry) {
+  if (Object.entries(lockfile).length < (isYarnBerry ? 2 : 1)) {
+    return false
+  }
   const [sampleKey, sampleValue] = Object.entries(lockfile)[isYarnBerry ? 1 : 0]
   return (
     sampleKey.match(/.*@.*/) &&

--- a/packages/lockfile-lint/__tests__/main.test.js
+++ b/packages/lockfile-lint/__tests__/main.test.js
@@ -188,7 +188,7 @@ describe('Main CLI logic', () => {
 
     test('should fail with an empty yarn lock file', () => {
       const lockfilePath = path.join(__dirname, '/fixtures/empty.json')
-      const lockfileType = 'yarn'
+      const lockfileType = 'npm'
       const validators = [
         {
           name: 'validateHosts',

--- a/packages/lockfile-lint/__tests__/main.test.js
+++ b/packages/lockfile-lint/__tests__/main.test.js
@@ -192,7 +192,7 @@ describe('Main CLI logic', () => {
       const validators = [
         {
           name: 'validateHosts',
-          values: ['npm']
+          values: ['yarn']
         }
       ]
 

--- a/packages/lockfile-lint/__tests__/main.test.js
+++ b/packages/lockfile-lint/__tests__/main.test.js
@@ -185,6 +185,27 @@ describe('Main CLI logic', () => {
           .toThrow('Lockfile does not seem to contain a valid dependency list')
       )
     })
+
+    test('should fail with an empty yarn lock file', () => {
+      const lockfilePath = path.join(__dirname, '/fixtures/empty.json')
+      const lockfileType = 'yarn'
+      const validators = [
+        {
+          name: 'validateHosts',
+          values: ['npm']
+        }
+      ]
+
+      expect(() =>
+        main
+          .runValidators({
+            path: lockfilePath,
+            type: lockfileType,
+            validators
+          })
+          .toThrow('Lockfile does not seem to contain a valid dependency list')
+      )
+    })
   })
 
   describe('validateSchemes', () => {

--- a/packages/lockfile-lint/__tests__/main.test.js
+++ b/packages/lockfile-lint/__tests__/main.test.js
@@ -171,7 +171,7 @@ describe('Main CLI logic', () => {
       const validators = [
         {
           name: 'validateHosts',
-          values: ['yarn']
+          values: ['npm']
         }
       ]
 

--- a/packages/lockfile-lint/__tests__/main.test.js
+++ b/packages/lockfile-lint/__tests__/main.test.js
@@ -171,7 +171,7 @@ describe('Main CLI logic', () => {
       const validators = [
         {
           name: 'validateHosts',
-          values: ['npm']
+          values: ['yarn']
         }
       ]
 

--- a/packages/lockfile-lint/__tests__/main.test.js
+++ b/packages/lockfile-lint/__tests__/main.test.js
@@ -164,6 +164,27 @@ describe('Main CLI logic', () => {
       expect(result.validatorCount).toEqual(1)
       expect(result.validatorSuccesses).toEqual(1)
     })
+
+    test('should fail with an empty npm lock file', () => {
+      const lockfilePath = path.join(__dirname, '/fixtures/empty.json')
+      const lockfileType = 'npm'
+      const validators = [
+        {
+          name: 'validateHosts',
+          values: ['npm']
+        }
+      ]
+
+      expect(() =>
+        main
+          .runValidators({
+            path: lockfilePath,
+            type: lockfileType,
+            validators
+          })
+          .toThrow('Lockfile does not seem to contain a valid dependency list')
+      )
+    })
   })
 
   describe('validateSchemes', () => {

--- a/packages/lockfile-lint/__tests__/main.test.js
+++ b/packages/lockfile-lint/__tests__/main.test.js
@@ -188,7 +188,7 @@ describe('Main CLI logic', () => {
 
     test('should fail with an empty yarn lock file', () => {
       const lockfilePath = path.join(__dirname, '/fixtures/empty.json')
-      const lockfileType = 'npm'
+      const lockfileType = 'yarn'
       const validators = [
         {
           name: 'validateHosts',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

fix error handling for empty yarn lock files (#158)

Currently, running any validator against an empty lock file results in a exception with a stack trace, like this:
```
$ touch yarn.lock && npx lockfile-lint@4.10.1 --path yarn.lock --type yarn --allowed-hosts yarn npm yarn
 ℹ ABORTING lockfile lint process due to error exceptions 
 
Unable to parse yarn lockfile "yarn.lock" 

TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))
    at checkSampleContent (/home/candrews/.npm/_npx/456ed9a151c5043a/node_modules/lockfile-lint-api/src/ParseLockfile.js:24:36)
    at yarnParseAndVerify (/home/candrews/.npm/_npx/456ed9a151c5043a/node_modules/lockfile-lint-api/src/ParseLockfile.js:41:49)
    at ParseLockfile.parseYarnLockfile (/home/candrews/.npm/_npx/456ed9a151c5043a/node_modules/lockfile-lint-api/src/ParseLockfile.js:160:20)
    at ParseLockfile.parseSync (/home/candrews/.npm/_npx/456ed9a151c5043a/node_modules/lockfile-lint-api/src/ParseLockfile.js:122:27)
    at ValidateHostManager (/home/candrews/.npm/_npx/456ed9a151c5043a/node_modules/lockfile-lint/src/validators/index.js:49:27)
    at /home/candrews/.npm/_npx/456ed9a151c5043a/node_modules/lockfile-lint/src/main.js:41:28
    at Array.forEach (<anonymous>)
    at Object.runValidators (/home/candrews/.npm/_npx/456ed9a151c5043a/node_modules/lockfile-lint/src/main.js:31:14)
    at Object.<anonymous> (/home/candrews/.npm/_npx/456ed9a151c5043a/node_modules/lockfile-lint/bin/lockfile-lint.js:80:17)
    at Module._compile (node:internal/modules/cjs/loader:1254:14) 

/home/candrews/.npm/_npx/456ed9a151c5043a/node_modules/lockfile-lint/bin/lockfile-lint.js:89
  error('Error: command failed with exit code 1')
  ^

TypeError: error is not a function
    at Object.<anonymous> (/home/candrews/.npm/_npx/456ed9a151c5043a/node_modules/lockfile-lint/bin/lockfile-lint.js:89:3)
    at Module._compile (node:internal/modules/cjs/loader:1254:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
    at Module.load (node:internal/modules/cjs/loader:1117:32)
    at Module._load (node:internal/modules/cjs/loader:958:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:23:47

Node.js v18.16.0
[1]
```

This PR fixes that issue by adding validation to the validators.

<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/lirantal/lockfile-lint/issues/158

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Empty lock files are not handled appropriately - this MR fixes that issue.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->

I've added two new unit tests (one for yarn, one for npm).

## Screenshots (if appropriate):

n/a

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have updated the documentation (if required).
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I added a picture of a cute animal cause it's fun

![image](https://github.com/lirantal/lockfile-lint/assets/194713/71e9f23e-680d-4e76-a98f-50ae1fd61060)

