### PR TITLE
fix: error variable was shadowed by function

### DIFF
--- a/packages/lockfile-lint/bin/lockfile-lint.js
+++ b/packages/lockfile-lint/bin/lockfile-lint.js
@@ -31,8 +31,8 @@ let config
 try {
   config = require('../src/config')(process.argv)
   debug(`parsed the following options: ${JSON.stringify(config)}`)
-} catch (err) {
-  debug(`error loading options from CLI arguments/files: ${err}`)
+} catch (errorPayload) {
+  debug(`error loading options from CLI arguments/files: ${errorPayload}`)
   process.exit(1)
 }
 
@@ -82,10 +82,10 @@ try {
     type: config['type'],
     validators
   })
-} catch (error) {
+} catch (errorPayload) {
   warn('ABORTING lockfile lint process due to error exceptions')
-  console.error(error.message, '\n')
-  console.error(error.stack, '\n')
+  console.error(errorPayload.message, '\n')
+  console.error(errorPayload.stack, '\n')
   error('Error: command failed with exit code 1')
   process.exit(1)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Prior to this fix, an error stack trace would be printed due to a bug in lockfile-lint's error handling.
It happened due to the `error()` function shadowing the local `error` variable in a try/catch scope.

<!--- Describe your changes in detail -->

## Types of changes

This PR fixes that undefined error.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation (if required).
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun
