### PR TITLE
fix: better error messages that use the long-form alias of CLI flags

### DIFF
--- a/.changeset/weak-grapes-drum.md
+++ b/.changeset/weak-grapes-drum.md
@@ -1,0 +1,5 @@
+---
+'lockfile-lint': patch
+---
+
+Friendly error messages by referencing the long-form CLI flag

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "linters": {
       "**/*.js": [
         "prettier-standard",
-        "npm run lint",
         "git add"
       ]
     }

--- a/packages/lockfile-lint/__tests__/cli.test.js
+++ b/packages/lockfile-lint/__tests__/cli.test.js
@@ -4,7 +4,11 @@ const path = require('path')
 // eslint-disable-next-line security/detect-child-process
 const childProcess = require('child_process')
 const cliExecPath = path.join(__dirname, '../bin/lockfile-lint.js')
-const {ValidateHostManager, ValidateUrlManager, ValidateIntegrityManager} = require('../src/validators/index')
+const {
+  ValidateHostManager,
+  ValidateUrlManager,
+  ValidateIntegrityManager
+} = require('../src/validators/index')
 
 describe('CLI tests', () => {
   test('Running without parameters should display help', done => {
@@ -194,7 +198,9 @@ describe('CLI tests', () => {
     })
 
     process.stderr.on('close', _ => {
-      expect(output.indexOf('Arguments o and validate-https are mutually exclusive')).not.toBe(-1)
+      expect(
+        output.indexOf('Arguments allowed-schemes and validate-https are mutually exclusive')
+      ).not.toBe(-1)
       done()
     })
   })

--- a/packages/lockfile-lint/__tests__/config.test.js
+++ b/packages/lockfile-lint/__tests__/config.test.js
@@ -45,7 +45,7 @@ describe('config', () => {
   })
 
   test('providing conflicting arguments should display an error', () => {
-    const errorMessageExpression = /arguments o and validate-https are mutually exclusive/i
+    const errorMessageExpression = /Arguments allowed-schemes and validate-https are mutually exclusive/i
 
     expect(() =>
       loadConfig(

--- a/packages/lockfile-lint/src/config.js
+++ b/packages/lockfile-lint/src/config.js
@@ -29,59 +29,59 @@ module.exports = (argv, exitProcess = false, searchFrom = process.cwd()) => {
     .help('help')
     .alias('help', 'h')
     .options({
-      p: {
-        alias: ['path'],
+      path: {
+        alias: ['p'],
         type: 'string',
         describe: 'path to the lockfile',
         demandOption: true
       },
-      t: {
-        alias: ['type'],
+      type: {
+        alias: ['t'],
         type: 'string',
         describe: 'lockfile type, options are "npm" or "yarn"'
       },
-      s: {
-        alias: ['validate-https'],
+      'validate-https': {
+        alias: ['s'],
         type: 'boolean',
         describe: 'validates the use of HTTPS as protocol schema for all resources'
       },
-      n: {
-        alias: ['validate-package-names'],
+      'validate-package-names': {
+        alias: ['n'],
         type: 'boolean',
         describe:
           "validates that the resource URL specifies the same package name as that listed as the lockfile entry's key",
         implies: 'allowed-hosts'
       },
-      i: {
-        alias: ['validate-integrity'],
+      'validate-integrity': {
+        alias: ['i'],
         type: 'boolean',
         describe: 'validates that the integrity hash type is sha512'
       },
-      e: {
-        alias: 'empty-hostname',
+      'empty-hostname': {
+        alias: 'e',
         type: 'boolean',
         default: true,
         describe: 'allows empty hostnames, or set to false if you wish for a stricter policy'
       },
-      a: {
-        alias: ['allowed-hosts'],
+      'allowed-hosts': {
+        alias: ['a'],
         type: 'array',
         describe: 'validates a whitelist of allowed hosts to be used for resources in the lockfile'
       },
-      o: {
-        alias: ['allowed-schemes'],
+      'allowed-schemes': {
+        alias: ['o'],
         type: 'array',
         describe:
           'validates a whitelist of allowed schemes to be used for resources in the lockfile',
         conflicts: ['validate-https', 's']
       },
-      u: {
-        alias: ['allowed-urls'],
+      'allowed-urls': {
+        alias: ['u'],
         type: 'array',
         describe: 'validates a whitelist of allowed URLs to be used for resources in the lockfile'
       },
-      f: {
-        alias: ['format'],
+      format: {
+        alias: ['f'],
         type: 'string',
         description: 'format of the report output',
         choices: ['plain', 'pretty'],


### PR DESCRIPTION
Fixes #115 by providing referencing the long-form alias path of a CLI flag if it has errors associated with it, rather than the short-form single letter flag.