### PR TITLE
fix: skip validating package names outside of public registries

### DIFF
--- a/packages/lockfile-lint-api/__tests__/validators.packageNames.test.js
+++ b/packages/lockfile-lint-api/__tests__/validators.packageNames.test.js
@@ -78,4 +78,20 @@ describe('Validator: PackageName', () => {
       errors: []
     })
   })
+
+  it('validator should skip if it doesnt recognize the official public registries', () => {
+    const mockedPackages = {
+      '@cxui/cypress-util@1.0.10': {
+        version: '1.0.10',
+        resolved:
+          'https://checkmarx.jfrog.io/artifactory/api/npm/team-npm/@cxui/cypress-util/-/@cxui/cypress-util-1.0.10.tgz#3134312351eb248c1c4561d393afc6d8c23b2943'
+      }
+    }
+
+    const validator = new ValidatePackageNames({packages: mockedPackages})
+    expect(validator.validate()).toEqual({
+      type: 'success',
+      errors: []
+    })
+  })
 })

--- a/packages/lockfile-lint-api/src/validators/ValidatePackageNames.js
+++ b/packages/lockfile-lint-api/src/validators/ValidatePackageNames.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const {REGISTRY} = require('../common/constants')
+
 module.exports = class ValidatePackageNames {
   constructor ({packages} = {}) {
     if (typeof packages !== 'object') {
@@ -22,6 +24,13 @@ module.exports = class ValidatePackageNames {
 
       try {
         const packageResolvedURL = new URL(packageMetadata.resolved)
+
+        // Only handle package name validation matching per registry URL
+        // when the registry is one of the official public registries:
+        if (!Object.values(REGISTRY).includes(packageResolvedURL.host)) {
+          continue
+        }
+
         const path = packageResolvedURL.pathname
         const packageNameFromResolved = path.split('/-/')[0].slice(1)
 


### PR DESCRIPTION
## Description

Fix #112 - when packages are used from registries outside of the public ones (like artifactory and such) then they may include a different URL convention to locate the package name.

This PR fixes lockfile-lint showing an error because it is actually unable to match the package name to the URL. The fix is to skip these cases. 

In the future we may treat this different, such as by allowing to specify a flag like package-name-url-prefixes where you can write https://checkmarx.jfrog.io/artifactory/api/npm/team-npm/ so that we parse everything after that to compare the package name for a match

<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

#112
