### PR TITLE
Feat/debug for extra verbose information

### DIFF
--- a/.changeset/hot-spiders-taste.md
+++ b/.changeset/hot-spiders-taste.md
@@ -1,0 +1,5 @@
+---
+'lockfile-lint-api': minor
+---
+
+Add verbose information in debug

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,6 @@
     "node_modules/@babel/code-frame": {
       "version": "7.22.5",
       "resolved": "http://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
-      "integrity": "",
       "dependencies": {
         "@babel/highlight": "^7.22.5"
       },
@@ -14667,10 +14666,11 @@
       }
     },
     "packages/lockfile-lint-api": {
-      "version": "5.5.5",
+      "version": "5.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@yarnpkg/parsers": "^3.0.0-rc.32",
+        "debug": "^4.3.4",
         "object-hash": "^3.0.0"
       },
       "devDependencies": {
@@ -14696,6 +14696,27 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "packages/lockfile-lint-api/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "packages/lockfile-lint-api/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "packages/lockfile-lint/node_modules/ansi-regex": {
       "version": "5.0.0",

--- a/packages/lockfile-lint-api/package.json
+++ b/packages/lockfile-lint-api/package.json
@@ -49,6 +49,7 @@
   },
   "dependencies": {
     "@yarnpkg/parsers": "^3.0.0-rc.32",
+    "debug": "^4.3.4",
     "object-hash": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/lockfile-lint-api/src/ParseLockfile.js
+++ b/packages/lockfile-lint-api/src/ParseLockfile.js
@@ -2,6 +2,8 @@
 /* eslint-disable security/detect-object-injection */
 'use strict'
 
+const debug = require('debug')('lockfile-lint')
+
 const path = require('path')
 const yarnParseSyml = require('@yarnpkg/parsers').parseSyml
 const hash = require('object-hash')
@@ -229,6 +231,8 @@ class ParseLockfile {
         // if (depName.indexOf('node_modules/') === 0) {
         //   depNameClean = depName.substring('node_modules/'.length)
         // }
+
+        debug(`dependency full name: ${depName}`)
         const depNameClean = this.extractedPackageName(depName)
 
         npmDepMap[`${depNameClean}@${depMetadata.version}-${hashedDepValues}`] = depMetadataShortend

--- a/packages/lockfile-lint-api/src/validators/ValidatePackageNames.js
+++ b/packages/lockfile-lint-api/src/validators/ValidatePackageNames.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const debug = require('debug')('lockfile-lint')
 const {REGISTRY} = require('../common/constants')
 
 module.exports = class ValidatePackageNames {
@@ -28,6 +29,11 @@ module.exports = class ValidatePackageNames {
         // Only handle package name validation matching per registry URL
         // when the registry is one of the official public registries:
         if (!Object.values(REGISTRY).includes(packageResolvedURL.host)) {
+          debug(
+            `skipping package name '${packageName}' validation for non-official registry '${
+              packageResolvedURL.origin
+            }'`
+          )
           continue
         }
 


### PR DESCRIPTION
## Description

This PR adds verbose information in debug mode (when using `DEBUG=lockfile-lint` as the prefix to running the CLI) to show any time package name validation gets skipped and to print the full name of a package (for cases of npm lockfile v3)

