### PR TITLE
Correct `--integrity-exclude` package name matching logic

### DIFF
--- a/packages/lockfile-lint-api/__tests__/validators.integrityHashType.test.js
+++ b/packages/lockfile-lint-api/__tests__/validators.integrityHashType.test.js
@@ -28,7 +28,7 @@ describe('Validator: Integrity', () => {
 
   it('validator should fail if not allowed hash type is used for a resource', () => {
     const mockedPackages = {
-      bolt11: {
+      'bolt11@1.4.1-3e38a8b13f29678e59705efec18f590e50272676': {
         integrity: 'sha1-1ZNEUixLxGSmWnMKxpUAf9tm3Yg='
       }
     }
@@ -39,8 +39,8 @@ describe('Validator: Integrity', () => {
       errors: [
         {
           message:
-            'detected invalid integrity hash type for package: bolt11\n    expected: sha512\n    actual: sha1-1ZNEUixLxGSmWnMKxpUAf9tm3Yg=\n',
-          package: 'bolt11'
+            'detected invalid integrity hash type for package: bolt11@1.4.1-3e38a8b13f29678e59705efec18f590e50272676\n    expected: sha512\n    actual: sha1-1ZNEUixLxGSmWnMKxpUAf9tm3Yg=\n',
+          package: 'bolt11@1.4.1-3e38a8b13f29678e59705efec18f590e50272676'
         }
       ]
     })
@@ -48,11 +48,11 @@ describe('Validator: Integrity', () => {
 
   it('validator should succeed if all resources are from an allowed hash type', () => {
     const mockedPackages = {
-      '@types/node': {
+      '@types/node@20.11.17-14733ac8d7ad65e47f20fc8c2b20bd58ef37c9f5': {
         integrity:
           'sha512-CK2fnrQlIgKlCV3N2kM+Gznb5USlwA1KFX3rJVHmgVk6NJxFPuQ86pAcvKnu37IA4BGlSRz7sEE1lHL1aLZ/eQ=='
       },
-      typescript: {
+      'typescript@5.0.0-d5998c40b92db6ac7b06359242cf43afc8b499f4': {
         integrity:
           'sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig=='
       }
@@ -67,11 +67,11 @@ describe('Validator: Integrity', () => {
 
   it('validator should not fail even if one of the packages has no `integrity` field', () => {
     const mockedPackages = {
-      typescript: {
+      'typescript@5.0.0-d5998c40b92db6ac7b06359242cf43afc8b499f4': {
         integrity:
           'sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig=='
       },
-      meow: {}
+      'meow@13.0.0-0478ab49a1d0b9808d0ea088db43c980a15dfc4b': {}
     }
     const validator = new ValidateIntegrity({packages: mockedPackages})
 
@@ -83,7 +83,7 @@ describe('Validator: Integrity', () => {
 
   it('validator should not fail if an excluded package has an invalid integrity hash type', () => {
     const mockedPackages = {
-      typescript: {
+      'typescript@5.0.0-d5998c40b92db6ac7b06359242cf43afc8b499f4': {
         integrity: 'sha1-1ZNEUixLxGSmWnMKxpUAf9tm3Yg='
       }
     }
@@ -95,6 +95,29 @@ describe('Validator: Integrity', () => {
     expect(validator.validate(options)).toEqual({
       type: 'success',
       errors: []
+    })
+  })
+
+  it('validator should not match excluded package by partial name', () => {
+    const mockedPackages = {
+      'common-prefix-package@1.0.0-30f09ab54e1d572758bd0673b8b96b5df96ec1fa': {
+        integrity: 'sha1-1ZNEUixLxGSmWnMKxpUAf9tm3Yg='
+      }
+    }
+    const options = {
+      integrityExclude: ['common-prefix']
+    }
+
+    const validator = new ValidateIntegrity({packages: mockedPackages})
+    expect(validator.validate(options)).toEqual({
+      type: 'error',
+      errors: [
+        {
+          message:
+            'detected invalid integrity hash type for package: common-prefix-package@1.0.0-30f09ab54e1d572758bd0673b8b96b5df96ec1fa\n    expected: sha512\n    actual: sha1-1ZNEUixLxGSmWnMKxpUAf9tm3Yg=\n',
+          package: 'common-prefix-package@1.0.0-30f09ab54e1d572758bd0673b8b96b5df96ec1fa'
+        }
+      ]
     })
   })
 

--- a/packages/lockfile-lint-api/src/validators/ValidateIntegrity.js
+++ b/packages/lockfile-lint-api/src/validators/ValidateIntegrity.js
@@ -29,7 +29,7 @@ module.exports = class ValidateIntegrity {
         continue
       }
 
-      if (excludedPackages.includes(packageName)) {
+      if (excludedPackages.find(name => packageName.startsWith(`${name}@`))) {
         continue
       }
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Update the matching logic for `--integrity-exclude` to check the excluded package name against the package identifier used internally. Update the corresponding test suite with more realistic mocking data. Add an extra test case to ensure package names aren't matched partially.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Followup to #188

## Motivation and Context

n/a

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->

- Unit testing
  (as seen in the diff)
- End-to-end testing
  (linked my clone of this project to the project mentioned in [#187](https://github.com/lirantal/lockfile-lint/issues/187) and checked that the configuration behaved as expected)

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun

_docs don't apply; no new cute animal picture, sorry_