### PR TITLE
Update README.md to fix cosmiconfig reference

### DIFF
--- a/packages/lockfile-lint/README.md
+++ b/packages/lockfile-lint/README.md
@@ -97,8 +97,8 @@ Lockfile-lint uses [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) f
 
 - A "lockfile-lint" key in your package.json file.
 - A .lockfile-lintrc file, written in JSON or YAML, with optional extensions: .json/.yaml/.yml (without extension takes precedence).
-- A .lockfile-lint.js or lockfile-lint.config.js file that exports an object.
-- A .lockfile-lint.toml file, written in TOML (the .toml extension is required).
+- A .lockfile-lintrc.js or lockfile-lint.config.js file that exports an object.
+- A .lockfile-lintrc.toml file, written in TOML (the .toml extension is required).
 
 The configuration file will be resolved starting from the current working directory, and searching up the file tree until a config file is (or isn't) found. Command-line options take precedence over any file-based configuration.
 

--- a/packages/lockfile-lint/README.md
+++ b/packages/lockfile-lint/README.md
@@ -98,7 +98,6 @@ Lockfile-lint uses [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) f
 - A "lockfile-lint" key in your package.json file.
 - A .lockfile-lintrc file, written in JSON or YAML, with optional extensions: .json/.yaml/.yml (without extension takes precedence).
 - A .lockfile-lintrc.js or lockfile-lint.config.js file that exports an object.
-- A .lockfile-lintrc.toml file, written in TOML (the .toml extension is required).
 
 The configuration file will be resolved starting from the current working directory, and searching up the file tree until a config file is (or isn't) found. Command-line options take precedence over any file-based configuration.
 


### PR DESCRIPTION
Fix the cosmiconfig docs

## Description

As noted in #192 `.lockfile-lint.js` is invalid. `.lockfile-lintrc.js` should be a valid Cosmiconfig with the default setup which you appear to be using.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

#192 

## Motivation and Context

Fixes invalid docs

## How Has This Been Tested?

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation (if required).
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun
