### PR TITLE
fix: add missing trailing slash

### DIFF
--- a/packages/lockfile-lint-api/__tests__/validators.packageNames.test.js
+++ b/packages/lockfile-lint-api/__tests__/validators.packageNames.test.js
@@ -15,7 +15,7 @@ describe('Validator: PackageName', () => {
 
   it('validator should fail if a resolved URL for a different package is found', () => {
     const failedPackage = 'meow'
-    const maliciousPackage = 'malicious'
+    const maliciousPackage = 'meowlicious'
     const mockedPackages = {
       '@babel/code-frame@^0.16.0': {
         resolved: 'https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz'

--- a/packages/lockfile-lint-api/src/validators/ValidatePackageNames.js
+++ b/packages/lockfile-lint-api/src/validators/ValidatePackageNames.js
@@ -53,7 +53,7 @@ module.exports = class ValidatePackageNames {
 
         const packageNameOnly = this._getPackageNameOnly(packageName)
 
-        const expectedURLBeginning = `${packageResolvedURL.origin}/${packageNameOnly}`
+        const expectedURLBeginning = `${packageResolvedURL.origin}/${packageNameOnly}/`
 
         const isPassing = packageMetadata.resolved.startsWith(expectedURLBeginning)
         if (!isPassing) {


### PR DESCRIPTION
### **User description**
## Description

Fix missing trailing slash in package name.

![image](https://github.com/user-attachments/assets/b68b8d02-788c-4d7e-96ea-e12a25210b8e)


## Checklist:

- [ x] I have updated the documentation (if required).
- [ x] I have read the **CONTRIBUTING** document.
- [ x] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
- [ x] I added a picture of a cute animal cause it's fun


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes missing trailing slash in resolved package URL validation.

- Updates test to use a more accurate malicious package name.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ValidatePackageNames.js</strong><dd><code>Add trailing slash to expected resolved URL prefix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/lockfile-lint-api/src/validators/ValidatePackageNames.js

<li>Adds a trailing slash to the expected URL prefix for package <br>validation.<br> <li> Ensures stricter matching of resolved package URLs.


</details>


  </td>
  <td><a href="https://github.com/lirantal/lockfile-lint/pull/204/files#diff-7b6dad04db36da63d356f1efef9b4d9c273ebd22c4f0d94ce3f6aa0777f95099">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>validators.packageNames.test.js</strong><dd><code>Update test with more accurate malicious package name</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/lockfile-lint-api/__tests__/validators.packageNames.test.js

<li>Changes test malicious package name from 'malicious' to 'meowlicious'.<br> <li> Improves test accuracy for package name validation.


</details>


  </td>
  <td><a href="https://github.com/lirantal/lockfile-lint/pull/204/files#diff-d81a81eb8fabd55cbb36bdbe851d7f9440e7b1170a1d858c69b23fa9ed208dd7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>