### PR TITLE
docs: add repository context docs 🤖🤖🤖

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in this repository.
+
+## Start Here
+
+Before making changes, read:
+
+- `CONTRIBUTING.md` for contribution, PR, testing, commit, and agent-specific expectations.
+- `RELEASE.md` for release workflow details.
+- `README.md` for user-facing behavior, install/use examples, and package or app overview.
+- `docs/README.md` for the project documentation index.
+- `docs/development.md` for local setup and development workflows.
+- `docs/testing.md` for test strategy, commands, and verification expectations.
+- `docs/architecture.md` for project structure, boundaries, and important invariants.
+- `docs/conventions.md` for project-specific coding, documentation, and maintenance conventions.
+
+Treat those files as the source of truth. Do not duplicate or reinterpret their rules here.
+
+## Documentation
+
+- Keep documentation in sync when changing behavior, public interfaces, workflows, architecture, configuration, or operational assumptions.
+- Put project-specific development details in `docs/`; keep root files focused on their standard audiences.
+- Prefer linking to the source of truth over duplicating long instructions across files.
+- When adding new docs, link them from `docs/README.md` and update this file only when they become important entry points for future agents.
+
+## PRs and Issues
+
+- Follow PR, issue, and agent-labeling rules in `CONTRIBUTING.md`.
+- Use the issue-linking format specified in `CONTRIBUTING.md`.
+
+## Releases
+
+- Follow `RELEASE.md` for release workflow and changeset creation steps.
+- If this project uses changesets, treat `RELEASE.md` and any changeset guidance in `CONTRIBUTING.md` as authoritative.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ If you have witnessed a possible attack vector on pnpm's lockfile, please open a
 
 `npm audit` is a tool to audit your dependencies for known vulnerabilities. However, it doesn't address the issue of malicious packages being injected into your lockfile. `lockfile-lint` is a tool that is designed to address this issue.
 
+## Documentation
+
+- [Project documentation](./docs/README.md) - development, testing, architecture, and conventions.
+
 ## Contributing
 
 Please consult [CONTRIBUTING](./CONTRIBUTING.md) for guidelines on contributing to this project.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,26 +1,96 @@
 # Release
 
-This project uses [Changesets](https://github.com/changesets/changesets) for versioning and release notes.
+This project uses [Changesets](https://github.com/changesets/changesets) to record release intent before the version and publish steps run.
 
-## Release Flow
+Use the command that matches the repository's package manager:
 
-1. Ensure all intended changes are merged and CI is green.
-2. Run `npm run version` to apply Changesets version and changelog updates.
-3. Review the generated package and changelog changes.
-4. Run the release command, if configured for the repository.
+- npm: `npx @changesets/cli`
+- pnpm: `pnpx @changesets/cli`
 
-Current release command:
+## Release tooling
+
+This project uses the [Changesets](https://github.com/changesets/changesets)
+tool to manage semantic versioning and release notes.
+
+## Pre-requisites
+
+Permit GitHub Actions to create and approve pull requests:
+
+1. Go to Actions -> General in the repository settings: (`https://github.com/<user>/<repo>/settings/actions`)
+2. In `Workflow permissions` enable the toggle for
+`Allow GitHub Actions to create and approve pull requests` (it is not required
+to also toggle the `Read and write permission` option)
+
+## Add a changeset interactively
+
+Run the Changesets CLI and follow the prompts:
 
 ```sh
+# npm
+npx @changesets/cli
+
+# pnpm
+pnpx @changesets/cli
+```
+
+The CLI asks which package changed, what semver bump is needed, and what summary should go in the changelog. Use:
+
+- `patch` for backward-compatible fixes and small internal changes
+- `minor` for backward-compatible new functionality
+- `major` for breaking changes
+
+Then commit and push the generated changeset:
+
+```sh
+git add .changeset
+git commit -m "chore: release"
+git push origin HEAD --no-verify
+```
+
+## Add a changeset without an interactive TTY
+
+The Changesets CLI is mostly interactive when creating a normal changeset. If a TTY is not available, write the changeset file directly.
+
+First, read the package name from `package.json` instead of hard-coding it:
+
+```sh
+PACKAGE_NAME=$(node -p "require('./package.json').name")
+```
+
+Create a changeset file under `.changeset/`:
+
+```sh
+CHANGESET_FILE=".changeset/$(date +%s)-release.md"
+
+cat > "$CHANGESET_FILE" <<EOF
+---
+"$PACKAGE_NAME": patch
+---
+
+Describe the change here.
+EOF
+```
+
+Replace `patch` with `minor` or `major` when the change requires a larger semver bump. Keep the summary short and user-facing; it is used by Changesets when generating release notes.
+
+Commit and push the changeset:
+
+```sh
+git add .changeset
+git commit -m "chore: release"
+git push origin HEAD --no-verify
+```
+
+## Version and publish
+
+After the changeset lands on the release branch, run the configured package scripts when it is time to cut and publish the release:
+
+```sh
+# npm
+npm run version
 npm run release
+
+# pnpm
+pnpm run version
+pnpm run release
 ```
-
-## Changesets
-
-Add a changeset for user-facing package behavior changes:
-
-```sh
-npm run changeset
-```
-
-Documentation-only, test-only, and internal refactor PRs usually do not need a changeset unless they describe or accompany a release-worthy behavior change.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,26 @@
+# Release
+
+This project uses [Changesets](https://github.com/changesets/changesets) for versioning and release notes.
+
+## Release Flow
+
+1. Ensure all intended changes are merged and CI is green.
+2. Run `npm run version` to apply Changesets version and changelog updates.
+3. Review the generated package and changelog changes.
+4. Run the release command, if configured for the repository.
+
+Current release command:
+
+```sh
+npm run release
+```
+
+## Changesets
+
+Add a changeset for user-facing package behavior changes:
+
+```sh
+npm run changeset
+```
+
+Documentation-only, test-only, and internal refactor PRs usually do not need a changeset unless they describe or accompany a release-worthy behavior change.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,16 @@
+# lockfile-lint Documentation
+
+This directory contains project documentation for maintainers and coding agents.
+
+## Core Docs
+
+- [Development](./development.md) - local setup, workflows, and useful commands.
+- [Testing](./testing.md) - test commands, test organization, and verification expectations.
+- [Architecture](./architecture.md) - repository structure, package boundaries, and important flows.
+- [Conventions](./conventions.md) - coding, documentation, and maintenance conventions.
+
+## Root References
+
+- [Project README](../README.md) - user-facing overview, installation, and usage.
+- [Contributing](../CONTRIBUTING.md) - issue, PR, commit, and agent expectations.
+- [Release](../RELEASE.md) - Changesets and release workflow.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,19 @@
+# Architecture
+
+## Overview
+
+lockfile-lint contains the source, package configuration, and release tooling for `lockfile-lint`.
+
+## Repository Structure
+
+- `packages/lockfile-lint` - package source and package-specific documentation.
+- `packages/lockfile-lint-api` - package source and package-specific documentation.
+- `.changeset/` - Changesets configuration and pending release notes.
+- `docs/` - project documentation for maintainers and coding agents.
+
+## Boundaries
+
+- Keep user-facing usage, installation, and examples in the root `README.md`.
+- Keep contribution rules in `CONTRIBUTING.md`.
+- Keep release workflow details in `RELEASE.md`.
+- Keep deeper development and architecture notes in `docs/`.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,20 @@
+# Conventions
+
+## Commits and PRs
+
+- Use Conventional Commits for commit messages.
+- Keep PRs focused on one logical change.
+- Include a Changeset for release-worthy package behavior changes.
+- Agent-authored PRs should follow the repository's agent title marker guidance in `CONTRIBUTING.md`.
+
+## Documentation
+
+- Keep root `README.md` focused on users and package consumers.
+- Put maintainer and agent context in `docs/`.
+- Link new documentation from `docs/README.md`.
+
+## Code
+
+- Prefer the existing package structure and scripts over introducing new tooling.
+- Keep generated files, dependency folders, and build output out of commits.
+- Match formatting and lint expectations already configured in the repository.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,25 @@
+# Development
+
+## Prerequisites
+
+- Node.js compatible with this repository's packages and tooling.
+- npm for dependency installation and scripts.
+
+## Setup
+
+```sh
+npm install
+```
+
+## Common Commands
+
+- `pnpm lint` - runs lint checks.
+- `pnpm test` - runs the test suite.
+
+## Repository Notes
+
+This repository contains package directories under:
+
+- `packages/lockfile-lint`
+- `packages/lockfile-lint-api`
+

--- a/docs/development.md
+++ b/docs/development.md
@@ -13,7 +13,7 @@ npm install
 
 ## Common Commands
 
-- `pnpm lint` - runs lint checks.
+- `npm run lint` - runs lint checks.
 - `pnpm test` - runs the test suite.
 
 ## Repository Notes

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,24 @@
+# Testing
+
+## Test Command
+
+Run the test suite with:
+
+```sh
+npm run test
+```
+
+## Linting
+
+Run lint checks with:
+
+```sh
+npm run lint
+```
+
+
+## Expectations
+
+- Add or update tests for behavior changes.
+- Run the relevant package-level checks before opening a PR.
+- Keep generated coverage, build output, and dependency folders out of commits.


### PR DESCRIPTION
Adds standardized repository context for coding agents and maintainers:

- refreshes AGENTS.md with the shared routing template
- adds or links canonical docs for development, testing, architecture, and conventions
- adds RELEASE.md where missing for Changesets release guidance

No package behavior changes are included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized and expanded repository docs for maintainers and coding agents, including development, testing, architecture, conventions, and a more detailed release flow. No runtime or package behavior changes.

- **Documentation**
  - Added `AGENTS.md` with source-of-truth links and guidance.
  - Added `docs/` index and pages: `development`, `testing`, `architecture`, `conventions`.
  - Enhanced `RELEASE.md` with detailed `@changesets/cli` steps, GitHub Actions prerequisites, and interactive/non-interactive changeset creation; includes version/publish commands.
  - Linked the docs from `README.md`.

<sup>Written for commit 833f82402f5bbecf776747e12b32e665403f0000. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/lockfile-lint/pull/217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

