### PR TITLE
build: replace fast-glob with tinyglobby

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18393,6 +18393,51 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/titleize": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
@@ -19821,8 +19866,8 @@
       "dependencies": {
         "cosmiconfig": "^9.0.0",
         "debug": "^4.3.4",
-        "fast-glob": "^3.3.2",
         "lockfile-lint-api": "^5.9.2",
+        "tinyglobby": "^0.2.15",
         "yargs": "^17.7.2"
       },
       "bin": {

--- a/packages/lockfile-lint/bin/lockfile-lint.js
+++ b/packages/lockfile-lint/bin/lockfile-lint.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const debug = require('debug')('lockfile-lint')
-const glob = require('fast-glob')
+const {globSync} = require('tinyglobby')
 const main = require('../src/main')
 
 const isSupported =
@@ -52,7 +52,7 @@ async function run () {
 
   let lockfilesList = []
   if (config.path) {
-    lockfilesList = glob.sync(config.path)
+    lockfilesList = globSync(config.path)
   }
 
   for (const lockfilePath of lockfilesList) {

--- a/packages/lockfile-lint/package.json
+++ b/packages/lockfile-lint/package.json
@@ -58,8 +58,8 @@
   "dependencies": {
     "cosmiconfig": "^9.0.0",
     "debug": "^4.3.4",
-    "fast-glob": "^3.3.2",
     "lockfile-lint-api": "^5.9.2",
+    "tinyglobby": "^0.2.15",
     "yargs": "^17.7.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

tinyglobby provides the same glob API surface with only two transitive dependencies (fdir, picomatch) instead of fast-glob's much larger tree (19 deps), reducing supply-chain exposure without changing the supported Node.js range (we could also migrate to fs.globSync, but that requires node 22+).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

reducing number of dependencies will both reduce the overall install size of this package, and reduce the number of transitive dependencies that consumers need to vet. Given this is a package focusing on lockfile health in general, I think it would be good that the package itself does not contribute to inflating the overall lockfile size too much.

## How Has This Been Tested?

Ran the test suite, and also tested the cli with glob options locally.

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `fast-glob` with `tinyglobby` in the CLI to shrink the dependency tree and reduce supply‑chain risk, with no behavior change or Node support change.

- **Dependencies**
  - Removed `fast-glob`; added `tinyglobby` (transitives: `fdir`, `picomatch`).
  - Updated CLI to use `globSync` from `tinyglobby`.
  - Keeps Node support the same; glob behavior unchanged.

<sup>Written for commit 82c8ffc19412350d4c1ebbf6a0dd49ea3e266e01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/lockfile-lint/pull/218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

