### PR TITLE
build: replace cosmiconfig with lilconfig

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4919,6 +4919,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -7314,14 +7315,6 @@
       "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
       "dev": true
     },
-    "node_modules/env-paths": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -9419,6 +9412,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -9434,6 +9428,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -14660,6 +14655,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -18971,7 +18967,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
       "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -19766,12 +19762,18 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
-      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
-      "dev": true,
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yaml-unist-parser": {
@@ -19861,13 +19863,14 @@
       }
     },
     "packages/lockfile-lint": {
-      "version": "4.14.1",
+      "version": "5.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "cosmiconfig": "^9.0.0",
         "debug": "^4.3.4",
+        "lilconfig": "^3.1.3",
         "lockfile-lint-api": "^5.9.2",
         "tinyglobby": "^0.2.15",
+        "yaml": "^2.9.0",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -19930,45 +19933,16 @@
         "node": ">=16.0.0"
       }
     },
-    "packages/lockfile-lint/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-    },
-    "packages/lockfile-lint/node_modules/cosmiconfig": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
-      "dependencies": {
-        "env-paths": "^2.2.1",
-        "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0"
-      },
+    "packages/lockfile-lint/node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "license": "MIT",
       "engines": {
         "node": ">=14"
       },
       "funding": {
-        "url": "https://github.com/sponsors/d-fischer"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.9.5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/lockfile-lint/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "url": "https://github.com/sponsors/antonk52"
       }
     }
   }

--- a/packages/lockfile-lint/__tests__/cli.test.js
+++ b/packages/lockfile-lint/__tests__/cli.test.js
@@ -378,8 +378,8 @@ describe('CLI tests', () => {
     })
   })
 
-  describe('cosmiconfig integration', () => {
-    test('options are loaded from cosmiconfig files', done => {
+  describe('config file integration', () => {
+    test('options are loaded from config files', done => {
       const lintProcess = childProcess.spawn('node', [cliExecPath], {
         cwd: path.join(__dirname, 'fixtures/valid-config')
       })

--- a/packages/lockfile-lint/__tests__/config.test.js
+++ b/packages/lockfile-lint/__tests__/config.test.js
@@ -109,8 +109,8 @@ describe('config', () => {
     })
   })
 
-  describe('cosmiconfig integration', () => {
-    it('options are loaded from cosmiconfig files', async () => {
+  describe('config file integration', () => {
+    it('options are loaded from config files', async () => {
       expect(
         await loadConfig(['lockfile-lint.js'], false, path.join(__dirname, 'fixtures/valid-config'))
       ).toEqual(

--- a/packages/lockfile-lint/package.json
+++ b/packages/lockfile-lint/package.json
@@ -56,10 +56,11 @@
     "directory": "packages/lockfile-lint"
   },
   "dependencies": {
-    "cosmiconfig": "^9.0.0",
     "debug": "^4.3.4",
+    "lilconfig": "^3.1.3",
     "lockfile-lint-api": "^5.9.2",
     "tinyglobby": "^0.2.15",
+    "yaml": "^2.9.0",
     "yargs": "^17.7.2"
   },
   "devDependencies": {

--- a/packages/lockfile-lint/src/config.js
+++ b/packages/lockfile-lint/src/config.js
@@ -2,12 +2,17 @@
 
 const debug = require('debug')('lockfile-lint')
 const yargs = require('yargs')
-const {cosmiconfig} = require('cosmiconfig')
+const {lilconfig} = require('lilconfig')
+const yaml = require('yaml')
+
+// the extension-less .lockfile-lintrc is parsed as YAML (a superset of JSON),
+// matching the behavior of cosmiconfig which lilconfig replaced
+const yamlLoader = (_, content) => yaml.parse(content)
 
 module.exports = async (argv, exitProcess = false, searchFrom = process.cwd()) => {
-  let cosmiconfigResult
+  let searchResult
   try {
-    const explorer = cosmiconfig('lockfile-lint', {
+    const explorer = lilconfig('lockfile-lint', {
       searchPlaces: [
         'package.json',
         '.lockfile-lintrc',
@@ -20,20 +25,26 @@ module.exports = async (argv, exitProcess = false, searchFrom = process.cwd()) =
         'lockfile-lint.config.js',
         'lockfile-lint.config.cjs',
         'lockfile-lint.config.mjs'
-      ]
+      ],
+      loaders: {
+        '.yaml': yamlLoader,
+        '.yml': yamlLoader,
+        noExt: yamlLoader
+      },
+      // only search in searchFrom itself, without traversing up the
+      // directory tree, matching cosmiconfig@9's default search strategy
+      stopDir: searchFrom
     })
-    cosmiconfigResult = await explorer.search(searchFrom)
+    searchResult = await explorer.search(searchFrom)
   } catch (err) {
     debug(`error encountered while loading configuration: ${err}`)
   }
 
   let fileConfig = {}
-  if (cosmiconfigResult) {
-    fileConfig = cosmiconfigResult.config
+  if (searchResult) {
+    fileConfig = searchResult.config
     debug(
-      `loaded the following config from ${cosmiconfigResult.filepath}: ${JSON.stringify(
-        fileConfig
-      )}`
+      `loaded the following config from ${searchResult.filepath}: ${JSON.stringify(fileConfig)}`
     )
   }
 


### PR DESCRIPTION
## Description

Swaps cosmiconfig (26 transitive packages, ~1.1MB) for lilconfig + yaml (2 zero-dependency packages, ~714KB) in the lockfile-lint CLI.

Config file loading behavior is preserved: YAML loaders are wired up for .lockfile-lintrc.yaml/.yml and the extension-less .lockfile-lintrc, and stopDir pins the search to the starting directory, matching cosmiconfig@9's default of not traversing up the directory tree.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Helps reduce supply chain risk and high dependency count of installing this package by using slimmer, more modern dependencies.

## How Has This Been Tested?

Ran test suite locally, and verified config with both json and yaml-based config.

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun


I hope it's okay I just opened this PR without no issue / prior discussion! I may want to look into a few of the other dependencies as well, if there's interest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `cosmiconfig` with `lilconfig` + `yaml` in the CLI to cut dependencies without changing config behavior. Search is pinned to the start directory, and `.lockfile-lintrc`, `.lockfile-lintrc.yaml/.yml`, and extension-less configs are parsed as YAML.

- **Dependencies**
  - Removed `cosmiconfig`; added `lilconfig` and `yaml`.
  - Reduced transitive deps from 26 (~1.1 MB) to 2 zero-dep packages (~714 KB).

<sup>Written for commit 64c225f1e7aed41c9772fb162f7bc792d5b87d1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/lockfile-lint/pull/219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

